### PR TITLE
chore: add maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 ## Maintainers
 
-- TODO
+- [Antoine Toulme](https://github.com/atoulme), [Splunk](https://www.splunk.com/)
+- [Damien Mathieu](https://github.com/dmathieu), [Elastic](https://www.elastic.co/)
+- [Denys Sedchenko](https://github.com/x1unix), [Grafana Labs](https://grafana.com/)
+- [Douglas Camata](https://github.com/douglascamata), [Coralogix](https://coralogix.com/)
+- [Michele Mancioppi](https://github.com/mmanciop), [Dash0](https://www.dash0.com/)
 
 For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).
 


### PR DESCRIPTION
List as maintainers all the people listed in the [Staff wanted](https://github.com/open-telemetry/community/blob/main/projects/packaging.md#staffing--help-wanted) section of the project.