### PR TITLE
fix: update OpenTelemetry Injector version to v0.10.1

### DIFF
--- a/packaging/common/injector/release.txt
+++ b/packaging/common/injector/release.txt
@@ -1,2 +1,2 @@
 # renovate: datasource=github-releases depName=open-telemetry/opentelemetry-injector
-v0.10.0
+v0.10.1


### PR DESCRIPTION
v0.10.1 of the injector fixes a crash on some Debian configurations, see https://github.com/open-telemetry/opentelemetry-injector/issues/399