### PR TITLE
docs: clarify declarative config as reference files and establish comment conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ make clean                     # Remove build/
 - Man pages use section 8 (system administration).
 - All config files are `config|noreplace` type in nfpm (preserved on upgrade).
 - nfpm `Info` structs must set `Platform: "linux"` explicitly — omitting it causes malformed `Architecture` fields in DEB packages.
+- In configuration files (`.conf`, `.yaml` shipped under `packaging/common/`), use `##` for prose/explanatory comments and `#` for commented-out configuration entries that users can activate by removing the `#` prefix.
 
 ## Prose rules
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ receivers:
        http:
          endpoint: 127.0.0.1:4318
 
+
 exporters:
   otlphttp:
     endpoint: https://otlp.example.com

--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ Point it at a real destination with one of the two options below.
 
 ### Option 1: Declarative SDK configuration file
 
-Every language package ships the same declarative configuration file at `/etc/opentelemetry/<language>/otel-config.yaml`.
-It is valid as shipped: it interpolates the endpoint, headers, and service name from environment variables the injector already injects into every instrumented process.
-Pointing it at a remote destination is therefore a matter of editing `/etc/opentelemetry/injector/default_env.conf`, the injector's single source of endpoint and credentials.
+Every language package installs a reference declarative configuration file at `/etc/opentelemetry/<language>/otel-config.yaml`.
+Use one as a starting point: copy or adapt it to a location of your choice.
+The schema is portable across all supported languages, so one central file covers Java, Node.js, .NET, and Python.
+The reference files interpolate the OTLP endpoint, headers, and service name from environment variables the injector injects, so `default_env.conf` remains the single source of credentials whether or not declarative configuration is active.
 
 Set the destination endpoint and any required headers, for example an API key:
 
@@ -71,11 +72,11 @@ OTEL_EXPORTER_OTLP_HEADERS=api-key=REPLACE_ME
 EOF
 ```
 
-Activate the shipped configuration file for the language you installed, for example Java:
+Activate your configuration file by setting `OTEL_CONFIG_FILE` to the path where you placed it:
 
 ```sh
 cat <<'EOF' | sudo tee -a /etc/opentelemetry/injector/default_env.conf
-OTEL_CONFIG_FILE=/etc/opentelemetry/java/otel-config.yaml
+OTEL_CONFIG_FILE=/etc/opentelemetry/config.yaml
 EOF
 ```
 
@@ -128,7 +129,6 @@ receivers:
          endpoint: 127.0.0.1:4317
        http:
          endpoint: 127.0.0.1:4318
-
 
 exporters:
   otlphttp:

--- a/packaging/common/dotnet/injector.conf
+++ b/packaging/common/dotnet/injector.conf
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-# .NET auto-instrumentation agent configuration
-# Installed by opentelemetry-dotnet-autoinstrumentation package
+## .NET auto-instrumentation agent configuration.
+## Installed by the opentelemetry-dotnet package.
 
 dotnet_auto_instrumentation_agent_path_prefix=/usr/lib/opentelemetry/dotnet

--- a/packaging/common/injector/default_env.conf
+++ b/packaging/common/injector/default_env.conf
@@ -1,12 +1,18 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-# Default environment variables for OpenTelemetry auto-instrumentation agents.
-# These variables are set for all instrumented applications unless overridden.
-#
-# Format: KEY=VALUE (one per line)
-# Lines starting with # are comments.
-#
-# Example:
+## Default environment variables for OpenTelemetry auto-instrumentation agents.
+## These variables are set for all instrumented applications unless overridden.
+##
+## Format: KEY=VALUE (one per line).
+## Lines starting with ## are prose comments; lines starting with # are commented-out options.
+##
+## Examples:
 # OTEL_SERVICE_NAME=my-service
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+##
+## To activate declarative SDK configuration, copy or adapt the reference file
+## shipped at /etc/opentelemetry/<language>/otel-config.yaml to a location of
+## your choice and set:
+# OTEL_CONFIG_FILE=/etc/opentelemetry/config.yaml
+# OTEL_EXPERIMENTAL_FILE_BASED_CONFIGURATION_ENABLED=true # (Only required by .NET.)

--- a/packaging/common/injector/injector.conf
+++ b/packaging/common/injector/injector.conf
@@ -1,24 +1,24 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-# OpenTelemetry Injector Configuration
-# This file configures the LD_PRELOAD-based automatic instrumentation injector.
+## OpenTelemetry Injector Configuration.
+## This file configures the LD_PRELOAD-based automatic instrumentation injector.
 
-# Path to the default environment variables file for all auto-instrumentation agents
+## Path to the default environment variables file for all auto-instrumentation agents.
 all_auto_instrumentation_agents_env_path=/etc/opentelemetry/injector/default_env.conf
 
-# Agent paths are configured via drop-in files in /etc/opentelemetry/injector/conf.d/
-# Each language package (e.g., opentelemetry-java-autoinstrumentation) installs its own
-# configuration file in that directory. Files are read in alphabetical order.
-#
-# To manually enable an agent, you can either:
-# 1. Install the corresponding package (recommended), or
-# 2. Create a file in conf.d/ with the appropriate path setting, e.g.:
-#    /etc/opentelemetry/injector/conf.d/99-custom.conf:
-#      jvm_auto_instrumentation_agent_path=/path/to/your/javaagent.jar
-#
-# Available settings:
-#   dotnet_auto_instrumentation_agent_path_prefix - .NET agent directory
-#   jvm_auto_instrumentation_agent_path - Java agent JAR file
-#   nodejs_auto_instrumentation_agent_path - Node.js agent entry point
-#   python_auto_instrumentation_agent_path_prefix - Python agent directory (prepended to PYTHONPATH)
+## Agent paths are configured via drop-in files in /etc/opentelemetry/injector/conf.d/.
+## Each language package (e.g., opentelemetry-java-autoinstrumentation) installs its own
+## configuration file in that directory. Files are read in alphabetical order.
+##
+## To manually enable an agent, you can either:
+## 1. Install the corresponding package (recommended), or
+## 2. Create a file in conf.d/ with the appropriate path setting, e.g.:
+##    /etc/opentelemetry/injector/conf.d/99-custom.conf:
+#       jvm_auto_instrumentation_agent_path=/path/to/your/javaagent.jar
+##
+## Available settings:
+##   dotnet_auto_instrumentation_agent_path_prefix - .NET agent directory
+##   jvm_auto_instrumentation_agent_path - Java agent JAR file
+##   nodejs_auto_instrumentation_agent_path - Node.js agent entry point
+##   python_auto_instrumentation_agent_path_prefix - Python agent directory (prepended to PYTHONPATH)

--- a/packaging/common/java/injector.conf
+++ b/packaging/common/java/injector.conf
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-# Java auto-instrumentation agent configuration
-# Installed by opentelemetry-java-autoinstrumentation package
+## Java auto-instrumentation agent configuration.
+## Installed by the opentelemetry-java package.
 
 jvm_auto_instrumentation_agent_path=/usr/lib/opentelemetry/java/opentelemetry-javaagent.jar

--- a/packaging/common/nodejs/injector.conf
+++ b/packaging/common/nodejs/injector.conf
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-# Node.js auto-instrumentation agent configuration
-# Installed by opentelemetry-nodejs-autoinstrumentation package
+## Node.js auto-instrumentation agent configuration.
+## Installed by the opentelemetry-nodejs package.
 
 nodejs_auto_instrumentation_agent_path=/usr/lib/opentelemetry/nodejs/register.js

--- a/packaging/common/otel-config.yaml
+++ b/packaging/common/otel-config.yaml
@@ -1,32 +1,35 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-# OpenTelemetry declarative configuration for the auto-instrumentation system
-# packages. One and the same file is shipped for every packaged language
-# agent (Java, Node.js, .NET, and Python); the schema is portable across
-# languages, and language-specific sections are ignored by the other SDKs.
-# See: https://opentelemetry.io/docs/languages/sdk-configuration/declarative-configuration/
-#
-# This file is inert until activated. To activate it for every injected
-# process, append to /etc/opentelemetry/injector/default_env.conf:
-#
-#   OTEL_CONFIG_FILE=/etc/opentelemetry/<language>/otel-config.yaml
-#   OTEL_EXPERIMENTAL_FILE_BASED_CONFIGURATION_ENABLED=true
-#
-# (The second line is only required by .NET and ignored by the others.)
-#
-# Once OTEL_CONFIG_FILE is in effect, the SDKs ignore all other OTEL_*
-# environment variables as direct configuration. The environment-variable
-# interpolations below deliberately keep consuming the variables the injector
-# injects, so default_env.conf remains the single source of endpoint and
-# credentials for both environment-variable-configured and declaratively
-# configured processes.
-#
-# Every interpolation carries a default: the Python SDK rejects a reference
-# to an unset variable that has none (Java and Node.js substitute an empty
-# string). For the same reason comments in this file must not contain
-# dollar-brace variable references: Python substitutes on the raw file text,
-# comments included.
+## OpenTelemetry declarative configuration for the auto-instrumentation system
+## packages. One and the same file is shipped for every packaged language
+## agent (Java, Node.js, .NET, and Python); the schema is portable across
+## languages, and language-specific sections are ignored by the other SDKs.
+## See: https://opentelemetry.io/docs/languages/sdk-configuration/declarative-configuration/
+##
+## Each language package installs this file at
+## /etc/opentelemetry/<language>/otel-config.yaml as a reference.
+## Use it as a starting point: copy or adapt it to a location of your choice,
+## then activate declarative configuration for every injected process by
+## appending to /etc/opentelemetry/injector/default_env.conf:
+##
+##   OTEL_CONFIG_FILE=/etc/opentelemetry/config.yaml
+##   OTEL_EXPERIMENTAL_FILE_BASED_CONFIGURATION_ENABLED=true
+##
+## (The second line is only required by .NET and ignored by the others.)
+##
+## Once OTEL_CONFIG_FILE is in effect, the SDKs ignore all other OTEL_*
+## environment variables as direct configuration. The environment-variable
+## interpolations below deliberately keep consuming the variables the injector
+## injects, so default_env.conf remains the single source of endpoint and
+## credentials for both environment-variable-configured and declaratively
+## configured processes.
+##
+## Every interpolation carries a default: the Python SDK rejects a reference
+## to an unset variable that has none (Java and Node.js substitute an empty
+## string). For the same reason comments in this file must not contain
+## dollar-brace variable references: Python substitutes on the raw file text,
+## comments included.
 
 file_format: "1.0"
 

--- a/packaging/common/python/injector.conf
+++ b/packaging/common/python/injector.conf
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-# Python auto-instrumentation agent configuration
-# Installed by opentelemetry-python-autoinstrumentation package
+## Python auto-instrumentation agent configuration.
+## Installed by the opentelemetry-python package.
 
 python_auto_instrumentation_agent_path_prefix=/usr/lib/opentelemetry/python


### PR DESCRIPTION
## Summary

- The `otel-config.yaml` shipped by each language package is a reference for users to copy and adapt to a central location, not a file to activate in-place at its per-language path. Updates `README.md`, `otel-config.yaml`, and `default_env.conf` to reflect this, with a concrete central-path example (`/etc/opentelemetry/config.yaml`).
- Establishes a comment convention across all `.conf` and config YAML files under `packaging/common/`: `##` for prose/explanatory comments, `#` for commented-out options users can activate by removing the prefix.
- Applies the convention consistently across all files under `packaging/common/`.

Related: #60