### PR TITLE
fix(deps): revert Python SDK to 1.43.0

### DIFF
--- a/packaging/common/python/requirements.txt
+++ b/packaging/common/python/requirements.txt
@@ -9,7 +9,7 @@ opentelemetry-distro==0.64b0
 # The file-configuration extra (pyyaml, jsonschema) enables declarative
 # configuration via OTEL_CONFIG_FILE; without it, setting that variable makes
 # the configurator crash with ModuleNotFoundError.
-opentelemetry-sdk[file-configuration]==1.44.0
+opentelemetry-sdk[file-configuration]==1.43.0
 
 urllib3 <2.7.1
 

--- a/packaging/tests/vendor/vendor_test.go
+++ b/packaging/tests/vendor/vendor_test.go
@@ -37,7 +37,7 @@ const (
 	vendorMarker = "ACME"
 	// upstreamDropInMarker appears in the upstream drop-in
 	// (packaging/common/java/injector.conf).
-	upstreamDropInMarker = "Installed by opentelemetry-java-autoinstrumentation package"
+	upstreamDropInMarker = "Installed by the opentelemetry-java package"
 )
 
 // target is one (package format, base image) combination in the test matrix.


### PR DESCRIPTION
## Summary

Renovate bumped `opentelemetry-sdk` to `1.44.0` in #30 but did not update the companion instrumentation packages.

The 0.65b0 ecosystem that would match 1.44.0 is not yet fully published on PyPI (opentelemetry-instrumentation-elasticsearch is still missing it).
Reverting the SDK pin to 1.43.0 is the only safe fix until the full 0.65b0 release lands.