### PR TITLE
Drop elasticsearch instrumentation and bump Python bundle to 1.44.0/0.65b0

### DIFF
--- a/packaging/common/python/requirements.txt
+++ b/packaging/common/python/requirements.txt
@@ -4,12 +4,12 @@
 # with opentelemetry-exporter-otlp-proto-http replaced by opentelemetry-exporter-otlp-pyproto-http
 # (pure-Python protobuf, no google-protobuf C-extension dependency).
 
-opentelemetry-distro==0.64b0
+opentelemetry-distro==0.65b0
 
 # The file-configuration extra (pyyaml, jsonschema) enables declarative
 # configuration via OTEL_CONFIG_FILE; without it, setting that variable makes
 # the configurator crash with ModuleNotFoundError.
-opentelemetry-sdk[file-configuration]==1.43.0
+opentelemetry-sdk[file-configuration]==1.44.0
 
 urllib3 <2.7.1
 
@@ -42,56 +42,55 @@ urllib3 <2.7.1
 
 opentelemetry-propagator-aws-xray==1.0.2
 
-opentelemetry-instrumentation==0.64b0
-opentelemetry-propagator-ot-trace==0.64b0
+opentelemetry-instrumentation==0.65b0
+opentelemetry-propagator-ot-trace==0.65b0
 
-opentelemetry-instrumentation-aio-pika==0.64b0
-opentelemetry-instrumentation-aiohttp-client==0.64b0
-opentelemetry-instrumentation-aiohttp-server==0.64b0
-opentelemetry-instrumentation-aiokafka==0.64b0
-opentelemetry-instrumentation-aiopg==0.64b0
-opentelemetry-instrumentation-asgi==0.64b0
-opentelemetry-instrumentation-asyncio==0.64b0
-opentelemetry-instrumentation-asyncpg==0.64b0
-opentelemetry-instrumentation-aws-lambda==0.64b0
+opentelemetry-instrumentation-aio-pika==0.65b0
+opentelemetry-instrumentation-aiohttp-client==0.65b0
+opentelemetry-instrumentation-aiohttp-server==0.65b0
+opentelemetry-instrumentation-aiokafka==0.65b0
+opentelemetry-instrumentation-aiopg==0.65b0
+opentelemetry-instrumentation-asgi==0.65b0
+opentelemetry-instrumentation-asyncio==0.65b0
+opentelemetry-instrumentation-asyncpg==0.65b0
+opentelemetry-instrumentation-aws-lambda==0.65b0
 # opentelemetry-instrumentation-boto (legacy boto v2) was removed upstream after
 # 0.61b0; boto3 workloads remain covered by botocore and boto3sqs below.
-opentelemetry-instrumentation-boto3sqs==0.64b0
-opentelemetry-instrumentation-botocore==0.64b0
-opentelemetry-instrumentation-cassandra==0.64b0
-opentelemetry-instrumentation-celery==0.64b0
-opentelemetry-instrumentation-click==0.64b0
-opentelemetry-instrumentation-confluent-kafka==0.64b0
-opentelemetry-instrumentation-dbapi==0.64b0
-opentelemetry-instrumentation-django==0.64b0
-opentelemetry-instrumentation-elasticsearch==0.64b0
-opentelemetry-instrumentation-falcon==0.64b0
-opentelemetry-instrumentation-fastapi==0.64b0
-opentelemetry-instrumentation-flask==0.64b0
-opentelemetry-instrumentation-grpc==0.64b0
-opentelemetry-instrumentation-httpx==0.64b0
-opentelemetry-instrumentation-jinja2==0.64b0
-opentelemetry-instrumentation-kafka-python==0.64b0
-opentelemetry-instrumentation-logging==0.64b0
-opentelemetry-instrumentation-mysql==0.64b0
-opentelemetry-instrumentation-mysqlclient==0.64b0
-opentelemetry-instrumentation-pika==0.64b0
-opentelemetry-instrumentation-psycopg==0.64b0
-opentelemetry-instrumentation-psycopg2==0.64b0
-opentelemetry-instrumentation-pymemcache==0.64b0
-opentelemetry-instrumentation-pymongo==0.64b0
-opentelemetry-instrumentation-pymysql==0.64b0
-opentelemetry-instrumentation-pyramid==0.64b0
-opentelemetry-instrumentation-redis==0.64b0
-opentelemetry-instrumentation-remoulade==0.64b0
-opentelemetry-instrumentation-requests==0.64b0
-opentelemetry-instrumentation-sqlalchemy==0.64b0
-opentelemetry-instrumentation-sqlite3==0.64b0
-opentelemetry-instrumentation-starlette==0.64b0
-opentelemetry-instrumentation-system-metrics==0.64b0
-opentelemetry-instrumentation-threading==0.64b0
-opentelemetry-instrumentation-tornado==0.64b0
-opentelemetry-instrumentation-tortoiseorm==0.64b0
-opentelemetry-instrumentation-urllib==0.64b0
-opentelemetry-instrumentation-urllib3==0.64b0
-opentelemetry-instrumentation-wsgi==0.64b0
+opentelemetry-instrumentation-boto3sqs==0.65b0
+opentelemetry-instrumentation-botocore==0.65b0
+opentelemetry-instrumentation-cassandra==0.65b0
+opentelemetry-instrumentation-celery==0.65b0
+opentelemetry-instrumentation-click==0.65b0
+opentelemetry-instrumentation-confluent-kafka==0.65b0
+opentelemetry-instrumentation-dbapi==0.65b0
+opentelemetry-instrumentation-django==0.65b0
+opentelemetry-instrumentation-falcon==0.65b0
+opentelemetry-instrumentation-fastapi==0.65b0
+opentelemetry-instrumentation-flask==0.65b0
+opentelemetry-instrumentation-grpc==0.65b0
+opentelemetry-instrumentation-httpx==0.65b0
+opentelemetry-instrumentation-jinja2==0.65b0
+opentelemetry-instrumentation-kafka-python==0.65b0
+opentelemetry-instrumentation-logging==0.65b0
+opentelemetry-instrumentation-mysql==0.65b0
+opentelemetry-instrumentation-mysqlclient==0.65b0
+opentelemetry-instrumentation-pika==0.65b0
+opentelemetry-instrumentation-psycopg==0.65b0
+opentelemetry-instrumentation-psycopg2==0.65b0
+opentelemetry-instrumentation-pymemcache==0.65b0
+opentelemetry-instrumentation-pymongo==0.65b0
+opentelemetry-instrumentation-pymysql==0.65b0
+opentelemetry-instrumentation-pyramid==0.65b0
+opentelemetry-instrumentation-redis==0.65b0
+opentelemetry-instrumentation-remoulade==0.65b0
+opentelemetry-instrumentation-requests==0.65b0
+opentelemetry-instrumentation-sqlalchemy==0.65b0
+opentelemetry-instrumentation-sqlite3==0.65b0
+opentelemetry-instrumentation-starlette==0.65b0
+opentelemetry-instrumentation-system-metrics==0.65b0
+opentelemetry-instrumentation-threading==0.65b0
+opentelemetry-instrumentation-tornado==0.65b0
+opentelemetry-instrumentation-tortoiseorm==0.65b0
+opentelemetry-instrumentation-urllib==0.65b0
+opentelemetry-instrumentation-urllib3==0.65b0
+opentelemetry-instrumentation-wsgi==0.65b0


### PR DESCRIPTION
## Summary

`opentelemetry-instrumentation-elasticsearch` was dropped upstream in
open-telemetry/opentelemetry-python-contrib#4759 because all supported
`elasticsearch` clients now ship native OpenTelemetry instrumentation. Its last
release is `0.64b0`, which hard-pins `opentelemetry-instrumentation==0.64b0`, so
keeping it in the bundle blocks every other package from moving to `0.65b0`
(this is what forced the temporary SDK revert in #64).

This PR:

- removes the `opentelemetry-instrumentation-elasticsearch` pin, and
- bumps the Python bundle to the current release now that the full set is
  resolvable:
  - `opentelemetry-sdk` `1.43.0` → `1.44.0`
  - `opentelemetry-distro`, `opentelemetry-instrumentation`,
    `opentelemetry-propagator-ot-trace` and all
    `opentelemetry-instrumentation-*` packages `0.64b0` → `0.65b0`

This reverses the temporary revert from #64.

## Validation

- Confirmed on PyPI that every bumped package has a `0.65b0` release
  (`opentelemetry-instrumentation-elasticsearch` is the only one that does not,
  hence its removal).
- `uv pip compile` resolves the full PyPI portion of the requirements cleanly
  (68 packages, no conflicts; API/SDK at `1.44.0`, contrib at `0.65b0`).

The recurring half of this problem — Renovate never advancing the
pre-release-only contrib pins — is addressed separately.