### PR TITLE
Track opentelemetry-python-contrib pre-release versions in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,6 +39,26 @@
       "schedule": [
         "before 8am on Tuesday"
       ]
+    },
+    {
+      // The opentelemetry-python-contrib packages (distro + every
+      // instrumentation) are only ever published as PEP 440 pre-releases
+      // (e.g. 0.65b0). Renovate treats pre-releases as unstable and skips
+      // them by default (ignoreUnstable), so these pins never advance while
+      // the stable opentelemetry-sdk (1.x.0) does - leaving the bundle in an
+      // inconsistent state. Opt into the pre-release stream and keep the SDK
+      // and contrib trains in a single PR so their pins stay mutually
+      // consistent.
+      "groupName": "opentelemetry-python",
+      "matchDatasources": ["pypi"],
+      "matchPackageNames": [
+        "opentelemetry-sdk",
+        "opentelemetry-distro",
+        "opentelemetry-instrumentation",
+        "opentelemetry-propagator-ot-trace",
+        "/^opentelemetry-instrumentation-/"
+      ],
+      "ignoreUnstable": false
     }
   ],
   "labels": [


### PR DESCRIPTION
## Summary

The `opentelemetry-python-contrib` packages (`opentelemetry-distro` and every
`opentelemetry-instrumentation-*` package) are only ever published as PEP 440
pre-releases, e.g. `0.65b0`. Renovate treats pre-releases as unstable and skips
them by default (`ignoreUnstable`), so their pins in
`packaging/common/python/requirements.txt` never advance — while the stable
`opentelemetry-sdk` (`1.x.0`) does. This is why #30 bumped only the SDK and left
the instrumentation packages behind, leaving the bundle inconsistent (and
contributing to the regression that #64 had to revert).

This PR adds a `packageRule` that:

- matches the OpenTelemetry PyPI packages,
- sets `ignoreUnstable: false` so the pre-release stream is tracked, and
- groups the SDK and contrib trains into a single PR so their pins stay
  mutually consistent.

## Notes

This is the automation half of the fix; the actual elasticsearch removal and
version bump to `1.44.0`/`0.65b0` is done in #66. The two are independent.