### PR TITLE
Add a post-install sanity check (otel-instrumentation-check)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ No Ruby, FPM, or special Docker images are required to build packages.
 cmd/build-packages/          CLI entry point for building .deb and .rpm packages
 cmd/build-spec/rpm/          CLI entry point for generating and staging the source RPM spec
 cmd/otel-config-check/       Declarative-config validator shipped inside the Python package
+cmd/otel-instrumentation-check/  Post-install sanity check shipped inside the injector package
 packaging/
   builder/                   Go library that drives nfpm to create packages
     builder.go               Build orchestration, common metadata

--- a/Makefile
+++ b/Makefile
@@ -71,24 +71,35 @@ TEST_LANGUAGES := java nodejs dotnet python
 otel-config-check:
 	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -trimpath -o build/bin/otel-config-check-$(ARCH) ./cmd/otel-config-check
 
+# Cross-compiles the otel-instrumentation-check post-install sanity check that
+# ships inside the injector package. Same pure-Go, CGO-disabled build as
+# otel-config-check.
+.PHONY: otel-instrumentation-check
+otel-instrumentation-check:
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -trimpath -o build/bin/otel-instrumentation-check-$(ARCH) ./cmd/otel-instrumentation-check
+
+# Both cross-compiled Go binaries the package builds embed.
+.PHONY: check-binaries
+check-binaries: otel-config-check otel-instrumentation-check
+
 .PHONY: deb-package-%
-deb-package-%: otel-config-check
+deb-package-%: check-binaries
 	go run ./cmd/build-packages -version $(VERSION) -arch $(ARCH) -format deb -component $* -output $(OUTPUT_DIR)
 
 .PHONY: deb-packages
-deb-packages: otel-config-check
+deb-packages: check-binaries
 	go run ./cmd/build-packages -version $(VERSION) -arch $(ARCH) -format deb -output $(OUTPUT_DIR)
 
 .PHONY: rpm-package-%
-rpm-package-%: otel-config-check
+rpm-package-%: check-binaries
 	go run ./cmd/build-packages -version $(VERSION) -arch $(ARCH) -format rpm -component $* -output $(OUTPUT_DIR)
 
 .PHONY: rpm-packages
-rpm-packages: otel-config-check
+rpm-packages: check-binaries
 	go run ./cmd/build-packages -version $(VERSION) -arch $(ARCH) -format rpm -output $(OUTPUT_DIR)
 
 .PHONY: packages
-packages: otel-config-check
+packages: check-binaries
 	go run ./cmd/build-packages -version $(VERSION) -arch $(ARCH) -format all -output $(OUTPUT_DIR)
 
 # ============================================================================
@@ -263,7 +274,7 @@ next-packaging-dir:
 		>> build/packaging-next/common/injector/default_env.conf
 
 .PHONY: local-apt-repo-next
-local-apt-repo-next: next-packaging-dir
+local-apt-repo-next: next-packaging-dir otel-instrumentation-check
 	@echo "Creating next-version APT repository in $(LOCAL_REPO_DIR)/apt-next"
 	go run ./cmd/build-packages -version $(NEXT_VERSION) -arch $(ARCH) -format deb \
 		-component injector -packaging-dir build/packaging-next -output build/packages-next/deb
@@ -275,7 +286,7 @@ local-apt-repo-next: next-packaging-dir
 		debian:12 /scripts/generate-apt-repo.sh /repo
 
 .PHONY: local-rpm-repo-next
-local-rpm-repo-next: next-packaging-dir
+local-rpm-repo-next: next-packaging-dir otel-instrumentation-check
 	@echo "Creating next-version RPM repository in $(LOCAL_REPO_DIR)/rpm-next"
 	go run ./cmd/build-packages -version $(NEXT_VERSION) -arch $(ARCH) -format rpm \
 		-component injector -packaging-dir build/packaging-next -output build/packages-next/rpm

--- a/README.md
+++ b/README.md
@@ -61,7 +61,14 @@ otel-instrumentation-check
 
 This command ships with the injector package and needs no running application and no OTLP receiver.
 The injector is a preloaded library rather than a service, so there is no daemon whose status could report "instrumentation is on"; the check instead reads the same files a newly started process would (`/etc/ld.so.preload`, the `conf.d/` drop-ins, and `default_env.conf`) and reports, per language, whether each registered agent is present on disk.
-It exits zero when the injector is active and at least one language agent is present, and non-zero otherwise, so it also works in a provisioning script.
+The check also scans the processes running right now and reports which of them are already instrumented and which started before the package was installed and so must be restarted to pick it up.
+It detects the latter by testing whether the injector library is mapped into each process through `/proc/<pid>/maps`; reading another user's process requires root, so run the check as root for full coverage.
+A mapped injector proves the injector ran in the process, not that the language SDK finished attaching, so the running-process result is the best signal available without a running application, not a guarantee.
+
+It exits zero when the injector is active, at least one language agent is present, and no running process needs a restart, so it also works in a provisioning script.
+It exits `1` when an installation problem is found, `2` on a usage error, and `3` when the installation is correct but one or more already-running processes must be restarted before they are instrumented.
+Code `3` is distinct from zero so a provisioning script can detect the "needs restart" case and restart the affected `systemd` units without treating it as an installation failure.
+
 It reports the configured telemetry destination too, so a missing backend is never mistaken for a broken install.
 
 ## Configuring where telemetry goes

--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ Install the full auto-instrumentation suite:
 sudo dnf install opentelemetry
 ```
 
+## Verifying the installation
+
+Confirm the injector is active and the language agents are wired up before pointing telemetry anywhere:
+
+```sh
+otel-instrumentation-check
+```
+
+This command ships with the injector package and needs no running application and no OTLP receiver.
+The injector is a preloaded library rather than a service, so there is no daemon whose status could report "instrumentation is on"; the check instead reads the same files a newly started process would (`/etc/ld.so.preload`, the `conf.d/` drop-ins, and `default_env.conf`) and reports, per language, whether each registered agent is present on disk.
+It exits zero when the injector is active and at least one language agent is present, and non-zero otherwise, so it also works in a provisioning script.
+It reports the configured telemetry destination too, so a missing backend is never mistaken for a broken install.
+
 ## Configuring where telemetry goes
 
 By default, every auto-instrumentation package exports OTLP to `localhost` (`localhost:4317` for OTLP/gRPC, and `localhost:4318` for OTLP/HTTP).

--- a/cmd/build-packages/main.go
+++ b/cmd/build-packages/main.go
@@ -40,6 +40,9 @@ func main() {
 	configCheckBinary := flag.String("config-check-binary", "",
 		"Path to a prebuilt otel-config-check binary for the target architecture "+
 			"(defaults to build/bin/otel-config-check-<arch>; build it with `make otel-config-check`)")
+	sanityCheckBinary := flag.String("sanity-check-binary", "",
+		"Path to a prebuilt otel-instrumentation-check binary for the target architecture "+
+			"(defaults to build/bin/otel-instrumentation-check-<arch>; build it with `make otel-instrumentation-check`)")
 
 	flag.Parse()
 
@@ -87,12 +90,22 @@ func main() {
 		log.Fatalf("error: %v", err)
 	}
 
+	sanityBinary := *sanityCheckBinary
+	if sanityBinary == "" {
+		sanityBinary = filepath.Join("build", "bin", "otel-instrumentation-check-"+*arch)
+	}
+	absSanityBinary, err := filepath.Abs(sanityBinary)
+	if err != nil {
+		log.Fatalf("error: %v", err)
+	}
+
 	cfg := builder.Config{
 		Version:           strings.TrimPrefix(*version, "v"),
 		Arch:              *arch,
 		PackagingDir:      pkgDir,
 		OutputDir:         absOutput,
 		ConfigCheckBinary: absCheckBinary,
+		SanityCheckBinary: absSanityBinary,
 	}
 
 	var formats []string

--- a/cmd/build-spec/rpm/main.go
+++ b/cmd/build-spec/rpm/main.go
@@ -33,6 +33,8 @@ func main() {
 	packagingDir := flag.String("packaging-dir", "", "Path to packaging/ directory (auto-detected if empty)")
 	configCheckBinary := flag.String("config-check-binary", "",
 		"Path to a prebuilt otel-config-check binary for the target architecture")
+	sanityCheckBinary := flag.String("sanity-check-binary", "",
+		"Path to a prebuilt otel-instrumentation-check binary for the target architecture")
 	stageRoot := flag.String("stage-root", "",
 		"Stage the payload into this rpmbuild %buildroot instead of generating a spec")
 	filelistDir := flag.String("filelist-dir", "",
@@ -85,11 +87,21 @@ func main() {
 		log.Fatalf("error: %v", err)
 	}
 
+	sanityBinary := *sanityCheckBinary
+	if sanityBinary == "" {
+		sanityBinary = filepath.Join("build", "bin", "otel-instrumentation-check-"+*arch)
+	}
+	absSanityBinary, err := filepath.Abs(sanityBinary)
+	if err != nil {
+		log.Fatalf("error: %v", err)
+	}
+
 	cfg := builder.Config{
 		Version:           strings.TrimPrefix(*version, "v"),
 		Arch:              *arch,
 		PackagingDir:      pkgDir,
 		ConfigCheckBinary: absCheckBinary,
+		SanityCheckBinary: absSanityBinary,
 	}
 
 	if *stageRoot != "" {

--- a/cmd/otel-instrumentation-check/main.go
+++ b/cmd/otel-instrumentation-check/main.go
@@ -1,0 +1,295 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// otel-instrumentation-check is a post-install sanity check for the
+// OpenTelemetry auto-instrumentation system packages. It confirms, without a
+// running OTLP receiver and without restarting an application, that the
+// injector is active and that the installed language agents are wired up
+// correctly.
+//
+// The injector is not a daemon: it is a shared library loaded into every
+// process through /etc/ld.so.preload, so there is no systemd unit whose status
+// could report "instrumentation is on". This command instead inspects the same
+// files the injector and its package lifecycle scripts read (/etc/ld.so.preload,
+// the conf.d/ drop-ins, and default_env.conf) and reports what a newly started
+// process would actually pick up.
+//
+// Usage: otel-instrumentation-check
+//
+// Exit codes: 0 the injector is active and at least one language agent is
+// registered and present; 1 a problem was found (details are printed to
+// stdout); 2 usage error.
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const usage = "usage: otel-instrumentation-check\n\n" +
+	"Verifies that the OpenTelemetry injector is active and that the installed\n" +
+	"language auto-instrumentation agents are wired up. Takes no arguments and\n" +
+	"needs no OTLP receiver."
+
+func main() {
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "-h", "--help":
+			fmt.Println(usage)
+			return
+		default:
+			fmt.Fprintln(os.Stderr, usage)
+			os.Exit(2)
+		}
+	}
+
+	results, ok := checkInstallation(systemLayout())
+
+	fmt.Println("OpenTelemetry auto-instrumentation post-install check")
+	fmt.Println()
+	for _, r := range results {
+		fmt.Println(r.format())
+	}
+	fmt.Println()
+
+	if ok {
+		fmt.Println("Result: PASS. The injector is active; newly started processes will be instrumented.")
+		return
+	}
+	fmt.Println("Result: FAIL. See the items marked [fail] above.")
+	os.Exit(1)
+}
+
+// layout locates the files the check inspects. The defaults are the FHS paths
+// the packages install to; tests point the fields at a temporary tree.
+type layout struct {
+	preloadFile  string // /etc/ld.so.preload
+	injectorLib  string // the injector shared library the preload file must list
+	injectorConf string // injector.conf, which may relocate the default env file
+	confDir      string // conf.d/, holding one drop-in per installed language
+	defaultEnv   string // default_env.conf, the OTEL_* variables applied to all agents
+}
+
+// systemLayout returns the layout for a real installation.
+func systemLayout() layout {
+	return layout{
+		preloadFile:  "/etc/ld.so.preload",
+		injectorLib:  "/usr/lib/opentelemetry/injector/libotelinject.so",
+		injectorConf: "/etc/opentelemetry/injector/injector.conf",
+		confDir:      "/etc/opentelemetry/injector/conf.d",
+		defaultEnv:   "/etc/opentelemetry/injector/default_env.conf",
+	}
+}
+
+// status is the severity of a single check result.
+type status int
+
+const (
+	statusOK status = iota
+	statusInfo
+	statusWarn
+	statusFail
+)
+
+// checkResult is one line of the report.
+type checkResult struct {
+	status  status
+	message string
+}
+
+// format renders a result as a grep-friendly, fixed-width-marker line.
+func (r checkResult) format() string {
+	marker := map[status]string{
+		statusOK:   "[ ok ]",
+		statusInfo: "[info]",
+		statusWarn: "[warn]",
+		statusFail: "[fail]",
+	}[r.status]
+	return marker + " " + r.message
+}
+
+// checkInstallation runs every check against the given layout and reports the
+// per-item results together with an overall pass/fail. The install passes when
+// the injector library is present, the preload file lists it, and at least one
+// language agent is registered with its files present on disk.
+func checkInstallation(l layout) (results []checkResult, ok bool) {
+	injectorPresent := isRegularFile(l.injectorLib)
+	if injectorPresent {
+		results = append(results, checkResult{statusOK, "injector library present: " + l.injectorLib})
+	} else {
+		results = append(results, checkResult{statusFail,
+			"injector library missing: " + l.injectorLib + " (reinstall the opentelemetry-injector package)"})
+	}
+
+	active := preloadListsInjector(l.preloadFile, l.injectorLib)
+	if active {
+		results = append(results, checkResult{statusOK, "injector active in " + l.preloadFile})
+	} else {
+		results = append(results, checkResult{statusFail,
+			"injector not listed in " + l.preloadFile + "; new processes are NOT instrumented"})
+	}
+
+	agentCount, agentResults := checkRegisteredAgents(l.confDir)
+	results = append(results, agentResults...)
+
+	// injector.conf may relocate the default environment file; honor it before
+	// reporting the telemetry destination.
+	if envPath := parseKeyValueFile(l.injectorConf)["all_auto_instrumentation_agents_env_path"]; envPath != "" {
+		l.defaultEnv = envPath
+	}
+	results = append(results, describeTelemetryDestination(l.defaultEnv)...)
+
+	ok = injectorPresent && active && agentCount > 0
+	return results, ok
+}
+
+// preloadListsInjector reports whether the preload file lists the injector
+// library. It field-splits every line on whitespace, matching how the dynamic
+// linker and the postinstall script treat /etc/ld.so.preload: several entries
+// may share a line, and only an exact path field counts.
+func preloadListsInjector(preloadFile, injectorLib string) bool {
+	data, err := os.ReadFile(preloadFile)
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		for _, field := range strings.Fields(line) {
+			if field == injectorLib {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// agentKey describes a conf.d setting that registers a language agent, how its
+// value resolves to an on-disk path, and the language it names.
+type agentKey struct {
+	key      string
+	language string
+	// prefix is true when the value is a path prefix under which the injector
+	// resolves the libc-specific subdirectory (glibc on every DEB/RPM target),
+	// rather than a direct path to the agent file.
+	prefix bool
+}
+
+// knownAgentKeys lists the conf.d settings this check understands, mirroring
+// the drop-in files each language package installs.
+var knownAgentKeys = []agentKey{
+	{"jvm_auto_instrumentation_agent_path", "Java", false},
+	{"nodejs_auto_instrumentation_agent_path", "Node.js", false},
+	{"dotnet_auto_instrumentation_agent_path_prefix", ".NET", true},
+	{"python_auto_instrumentation_agent_path_prefix", "Python", true},
+}
+
+// checkRegisteredAgents inspects the conf.d drop-ins and reports, per language,
+// whether the registered agent path exists on disk. It returns the number of
+// agents found present, so the caller can require at least one.
+func checkRegisteredAgents(confDir string) (count int, results []checkResult) {
+	drops, err := filepath.Glob(filepath.Join(confDir, "*.conf"))
+	if err != nil || len(drops) == 0 {
+		return 0, []checkResult{{statusFail,
+			"no language agents registered in " + confDir +
+				" (install a language package, e.g. opentelemetry-python-autoinstrumentation)"}}
+	}
+	sort.Strings(drops)
+
+	for _, drop := range drops {
+		settings := parseKeyValueFile(drop)
+		base := filepath.Base(drop)
+		for _, ak := range knownAgentKeys {
+			value, present := settings[ak.key]
+			if !present {
+				continue
+			}
+			resolved := value
+			if ak.prefix {
+				// The injector prepends the libc subdirectory; glibc is the only
+				// flavor these packages ship for DEB and RPM targets.
+				resolved = filepath.Join(value, "glibc")
+			}
+			if pathExists(resolved) {
+				count++
+				results = append(results, checkResult{statusOK,
+					ak.language + " agent registered (" + base + "): " + resolved})
+			} else {
+				results = append(results, checkResult{statusFail,
+					ak.language + " agent registered (" + base + ") but its files are missing: " + resolved})
+			}
+		}
+	}
+
+	if len(results) == 0 {
+		results = append(results, checkResult{statusFail,
+			"no recognized language agents registered in " + confDir})
+	}
+	return count, results
+}
+
+// describeTelemetryDestination reports where a newly instrumented process would
+// send its telemetry, so the user knows what to expect without standing up a
+// backend. It never fails the check: the destination is a configuration choice,
+// not an installation defect.
+func describeTelemetryDestination(defaultEnv string) []checkResult {
+	env := parseKeyValueFile(defaultEnv)
+	var results []checkResult
+
+	if configFile, declarative := env["OTEL_CONFIG_FILE"]; declarative {
+		if isRegularFile(configFile) {
+			results = append(results, checkResult{statusOK,
+				"declarative configuration active: OTEL_CONFIG_FILE=" + configFile +
+					" (validate it with otel-config-check)"})
+		} else {
+			results = append(results, checkResult{statusWarn,
+				"OTEL_CONFIG_FILE=" + configFile + " is set but the file is missing;" +
+					" instrumentation falls back to environment-variable configuration"})
+		}
+	}
+
+	endpoint, set := env["OTEL_EXPORTER_OTLP_ENDPOINT"]
+	if !set {
+		endpoint = "http://localhost:4317 (gRPC) or http://localhost:4318 (HTTP), the default"
+	}
+	results = append(results, checkResult{statusInfo,
+		"telemetry destination: " + endpoint +
+			". No OTLP receiver is needed for this check, but one must be reachable for telemetry to arrive."})
+	return results
+}
+
+// parseKeyValueFile reads a KEY=VALUE file (injector.conf, default_env.conf, or
+// a conf.d drop-in), skipping blank lines and comments. Later entries win, as
+// they do for the injector.
+func parseKeyValueFile(path string) map[string]string {
+	out := map[string]string{}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return out
+	}
+	for _, raw := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			continue
+		}
+		out[strings.TrimSpace(line[:eq])] = strings.TrimSpace(line[eq+1:])
+	}
+	return out
+}
+
+// isRegularFile reports whether path is an existing regular file.
+func isRegularFile(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular()
+}
+
+// pathExists reports whether path exists (of any type).
+func pathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/cmd/otel-instrumentation-check/main.go
+++ b/cmd/otel-instrumentation-check/main.go
@@ -16,9 +16,14 @@
 //
 // Usage: otel-instrumentation-check
 //
-// Exit codes: 0 the injector is active and at least one language agent is
-// registered and present; 1 a problem was found (details are printed to
-// stdout); 2 usage error.
+// Exit codes: 0 the injector is active, at least one language agent is
+// registered and present, and no running process needs a restart; 1 an
+// installation problem was found (details are printed to stdout); 2 usage error;
+// 3 the installation is correct but one or more already-running processes started
+// before the package was installed and must be restarted before they are
+// instrumented. Code 3 is distinct from 0 so a provisioning script can detect
+// the "needs restart" case and act on it (for example, restart the affected
+// systemd units) without treating it as an installation failure.
 package main
 
 import (
@@ -32,7 +37,21 @@ import (
 const usage = "usage: otel-instrumentation-check\n\n" +
 	"Verifies that the OpenTelemetry injector is active and that the installed\n" +
 	"language auto-instrumentation agents are wired up. Takes no arguments and\n" +
-	"needs no OTLP receiver."
+	"needs no OTLP receiver.\n\n" +
+	"Exit codes:\n" +
+	"  0  the injector is active, an agent is present, and no running process\n" +
+	"     needs a restart\n" +
+	"  1  an installation problem was found\n" +
+	"  2  usage error\n" +
+	"  3  the installation is correct but one or more already-running processes\n" +
+	"     started before install and must be restarted to be instrumented"
+
+// Exit codes. 0 (success) is Go's implicit default and is not named here.
+const (
+	exitInstallProblem = 1 // an installation problem was found
+	exitUsage          = 2 // usage error
+	exitNeedsRestart   = 3 // install OK, but running processes must be restarted
+)
 
 func main() {
 	if len(os.Args) > 1 {
@@ -42,11 +61,13 @@ func main() {
 			return
 		default:
 			fmt.Fprintln(os.Stderr, usage)
-			os.Exit(2)
+			os.Exit(exitUsage)
 		}
 	}
 
 	results, ok := checkInstallation(systemLayout())
+	processResults, needsRestart := describeRunningProcesses(scanRunningProcesses(systemProcLayout()))
+	results = append(results, processResults...)
 
 	fmt.Println("OpenTelemetry auto-instrumentation post-install check")
 	fmt.Println()
@@ -55,12 +76,19 @@ func main() {
 	}
 	fmt.Println()
 
-	if ok {
-		fmt.Println("Result: PASS. The injector is active; newly started processes will be instrumented.")
-		return
+	// An installation problem outranks a needs-restart: if the injector is not
+	// wired up, restarting a process would not help, so report the install
+	// failure first.
+	if !ok {
+		fmt.Println("Result: FAIL. See the items marked [fail] above.")
+		os.Exit(exitInstallProblem)
 	}
-	fmt.Println("Result: FAIL. See the items marked [fail] above.")
-	os.Exit(1)
+	if needsRestart {
+		fmt.Println("Result: ACTION NEEDED. The injector is active, but some already-running " +
+			"processes started before install and must be restarted to be instrumented; see the [warn] items above.")
+		os.Exit(exitNeedsRestart)
+	}
+	fmt.Println("Result: PASS. The injector is active; newly started processes will be instrumented.")
 }
 
 // layout locates the files the check inspects. The defaults are the FHS paths

--- a/cmd/otel-instrumentation-check/main_test.go
+++ b/cmd/otel-instrumentation-check/main_test.go
@@ -1,0 +1,194 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// installedLayout builds a fully valid installation under a temp directory:
+// the injector library present, listed in ld.so.preload, and a Python agent
+// registered with its files on disk. Individual tests then break one piece to
+// exercise a failure mode.
+func installedLayout(t *testing.T) layout {
+	t.Helper()
+	root := t.TempDir()
+
+	libDir := filepath.Join(root, "usr/lib/opentelemetry/injector")
+	require.NoError(t, os.MkdirAll(libDir, 0o755))
+	injectorLib := filepath.Join(libDir, "libotelinject.so")
+	require.NoError(t, os.WriteFile(injectorLib, []byte("so"), 0o755))
+
+	preloadFile := filepath.Join(root, "etc/ld.so.preload")
+	require.NoError(t, os.MkdirAll(filepath.Dir(preloadFile), 0o755))
+	require.NoError(t, os.WriteFile(preloadFile, []byte(injectorLib+"\n"), 0o644))
+
+	confDir := filepath.Join(root, "etc/opentelemetry/injector/conf.d")
+	require.NoError(t, os.MkdirAll(confDir, 0o755))
+
+	pythonPrefix := filepath.Join(root, "usr/lib/opentelemetry/python")
+	require.NoError(t, os.MkdirAll(filepath.Join(pythonPrefix, "glibc"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(confDir, "python.conf"),
+		[]byte("python_auto_instrumentation_agent_path_prefix="+pythonPrefix+"\n"), 0o644))
+
+	injectorConf := filepath.Join(root, "etc/opentelemetry/injector/injector.conf")
+	defaultEnv := filepath.Join(root, "etc/opentelemetry/injector/default_env.conf")
+	require.NoError(t, os.WriteFile(injectorConf,
+		[]byte("all_auto_instrumentation_agents_env_path="+defaultEnv+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(defaultEnv, []byte("## defaults\n"), 0o644))
+
+	return layout{
+		preloadFile:  preloadFile,
+		injectorLib:  injectorLib,
+		injectorConf: injectorConf,
+		confDir:      confDir,
+		defaultEnv:   defaultEnv,
+	}
+}
+
+// messages joins every result message so tests can assert on substrings
+// regardless of ordering details.
+func messages(results []checkResult) string {
+	var b strings.Builder
+	for _, r := range results {
+		b.WriteString(r.format())
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func TestHealthyInstallationPasses(t *testing.T) {
+	results, ok := checkInstallation(installedLayout(t))
+	assert.True(t, ok, "a complete installation must pass:\n%s", messages(results))
+	assert.Contains(t, messages(results), "injector active")
+	assert.Contains(t, messages(results), "Python agent registered")
+}
+
+func TestMissingInjectorLibraryFails(t *testing.T) {
+	l := installedLayout(t)
+	require.NoError(t, os.Remove(l.injectorLib))
+	results, ok := checkInstallation(l)
+	assert.False(t, ok)
+	assert.Contains(t, messages(results), "injector library missing")
+}
+
+func TestInjectorNotInPreloadFails(t *testing.T) {
+	l := installedLayout(t)
+	require.NoError(t, os.WriteFile(l.preloadFile, []byte("/opt/other/lib.so\n"), 0o644))
+	results, ok := checkInstallation(l)
+	assert.False(t, ok)
+	assert.Contains(t, messages(results), "not listed in")
+}
+
+// TestPreloadEntrySharingALineIsMatched pins that a preload file with several
+// whitespace-separated entries on one line still matches the injector, the way
+// the dynamic linker and the postinstall script treat it.
+func TestPreloadEntrySharingALineIsMatched(t *testing.T) {
+	l := installedLayout(t)
+	require.NoError(t, os.WriteFile(l.preloadFile,
+		[]byte("/opt/other/lib.so "+l.injectorLib+"\n"), 0o644))
+	results, ok := checkInstallation(l)
+	assert.True(t, ok, messages(results))
+}
+
+func TestNoAgentsRegisteredFails(t *testing.T) {
+	l := installedLayout(t)
+	require.NoError(t, os.Remove(filepath.Join(l.confDir, "python.conf")))
+	results, ok := checkInstallation(l)
+	assert.False(t, ok)
+	assert.Contains(t, messages(results), "no language agents registered")
+}
+
+func TestRegisteredAgentWithMissingFilesFails(t *testing.T) {
+	l := installedLayout(t)
+	// Point the drop-in at a prefix whose glibc/ subdirectory does not exist.
+	require.NoError(t, os.WriteFile(filepath.Join(l.confDir, "python.conf"),
+		[]byte("python_auto_instrumentation_agent_path_prefix=/nonexistent/python\n"), 0o644))
+	results, ok := checkInstallation(l)
+	assert.False(t, ok)
+	assert.Contains(t, messages(results), "its files are missing")
+}
+
+// TestAllLanguageAgentsRecognized pins that every conf.d key a language package
+// installs is understood and resolves to the right on-disk path.
+func TestAllLanguageAgentsRecognized(t *testing.T) {
+	l := installedLayout(t)
+	root := filepath.Dir(filepath.Dir(l.preloadFile)) // root/etc/ld.so.preload -> root
+
+	javaJar := filepath.Join(root, "usr/lib/opentelemetry/java/opentelemetry-javaagent.jar")
+	require.NoError(t, os.MkdirAll(filepath.Dir(javaJar), 0o755))
+	require.NoError(t, os.WriteFile(javaJar, []byte("jar"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(l.confDir, "java.conf"),
+		[]byte("jvm_auto_instrumentation_agent_path="+javaJar+"\n"), 0o644))
+
+	nodeEntry := filepath.Join(root, "usr/lib/opentelemetry/nodejs/register.js")
+	require.NoError(t, os.MkdirAll(filepath.Dir(nodeEntry), 0o755))
+	require.NoError(t, os.WriteFile(nodeEntry, []byte("js"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(l.confDir, "nodejs.conf"),
+		[]byte("nodejs_auto_instrumentation_agent_path="+nodeEntry+"\n"), 0o644))
+
+	dotnetPrefix := filepath.Join(root, "usr/lib/opentelemetry/dotnet")
+	require.NoError(t, os.MkdirAll(filepath.Join(dotnetPrefix, "glibc"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(l.confDir, "dotnet.conf"),
+		[]byte("dotnet_auto_instrumentation_agent_path_prefix="+dotnetPrefix+"\n"), 0o644))
+
+	count, results := checkRegisteredAgents(l.confDir)
+	msg := messages(results)
+	assert.Equal(t, 4, count, msg)
+	for _, language := range []string{"Java", "Node.js", ".NET", "Python"} {
+		assert.Contains(t, msg, language+" agent registered")
+	}
+}
+
+func TestDeclarativeConfigReported(t *testing.T) {
+	l := installedLayout(t)
+	configPath := filepath.Join(t.TempDir(), "otel-config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("file_format: \"1.0\"\n"), 0o644))
+	require.NoError(t, os.WriteFile(l.defaultEnv,
+		[]byte("OTEL_CONFIG_FILE="+configPath+"\n"), 0o644))
+
+	results, ok := checkInstallation(l)
+	assert.True(t, ok, messages(results))
+	assert.Contains(t, messages(results), "declarative configuration active")
+}
+
+func TestMissingDeclarativeConfigWarnsButDoesNotFail(t *testing.T) {
+	l := installedLayout(t)
+	require.NoError(t, os.WriteFile(l.defaultEnv,
+		[]byte("OTEL_CONFIG_FILE=/etc/opentelemetry/does-not-exist.yaml\n"), 0o644))
+
+	results, ok := checkInstallation(l)
+	assert.True(t, ok, "a missing OTEL_CONFIG_FILE is a warning, not an install defect")
+	assert.Contains(t, messages(results), "is set but the file is missing")
+}
+
+func TestCustomEndpointReported(t *testing.T) {
+	l := installedLayout(t)
+	require.NoError(t, os.WriteFile(l.defaultEnv,
+		[]byte("OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.example.com\n"), 0o644))
+	results, _ := checkInstallation(l)
+	assert.Contains(t, messages(results), "https://otlp.example.com")
+}
+
+func TestDefaultEndpointReportedWhenUnset(t *testing.T) {
+	results, _ := checkInstallation(installedLayout(t))
+	assert.Contains(t, messages(results), "localhost:4317")
+}
+
+func TestParseKeyValueFileSkipsCommentsAndBlanks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "conf")
+	require.NoError(t, os.WriteFile(path, []byte(
+		"# a comment\n\n## prose\nKEY = value \n#OTHER=commented\nLAST=x=y\n"), 0o644))
+	got := parseKeyValueFile(path)
+	assert.Equal(t, "value", got["KEY"])
+	assert.Equal(t, "x=y", got["LAST"], "only the first = splits key from value")
+	_, hasComment := got["#OTHER"]
+	assert.False(t, hasComment)
+}

--- a/cmd/otel-instrumentation-check/processes.go
+++ b/cmd/otel-instrumentation-check/processes.go
@@ -1,0 +1,257 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// This file answers the question issue #61 ultimately asks: of the applications
+// running right now, which are already being monitored and which are not (and
+// therefore must be restarted to pick up the instrumentation).
+//
+// The injector is the shared library listed in /etc/ld.so.preload. The dynamic
+// linker reads that file only at process startup, so a process started before
+// the package was installed never mapped the injector and never will until it
+// restarts. The ground-truth, restart-detecting signal is therefore whether
+// libotelinject.so is currently mapped into the process address space, which is
+// readable at /proc/<pid>/maps. This does not require a restart, an OTLP
+// receiver, or the injector's own logs.
+//
+// Semantic limitation: a mapped libotelinject.so proves the injector ran in the
+// process, not that the language SDK finished attaching and is healthy. The
+// injector could have run and the agent could still have failed to initialize
+// for a runtime-specific reason. This scan is therefore the best signal
+// available today, but it is a proxy for "monitored", not a guarantee. The
+// report wording says so, and a future per-process SDK health mechanism would be
+// needed for a definitive answer.
+//
+// Runtime-detection limitation: a process is matched to a runtime by a substring
+// of its command name (/proc/<pid>/comm) and argv[0] (/proc/<pid>/cmdline). This
+// is intentionally simple. It can misfire (a wrapper binary literally named
+// "java-foo" matches "java") or miss an interpreter reached only through exec
+// with an unrelated argv[0]. The report notes this so a surprising entry is
+// understood as a detection artifact, not a defect.
+
+// procState is how a running candidate process relates to the injector.
+type procState int
+
+const (
+	// procMonitored: the injector library is mapped into the process, so it
+	// started after the package was installed and is being instrumented.
+	procMonitored procState = iota
+	// procNeedsRestart: the process runs a supported runtime but the injector
+	// is not mapped, so it started before install and must be restarted.
+	procNeedsRestart
+)
+
+// runningProcess is one candidate process the scan considered.
+type runningProcess struct {
+	pid     int
+	comm    string // the process's command name, for a human-readable report
+	runtime string // the supported runtime detected (Java, Node.js, .NET, Python)
+	state   procState
+}
+
+// procScan is the outcome of walking /proc: the classified candidate processes,
+// whether /proc itself was unreadable (so the scan could not run at all), and
+// whether at least one candidate process could not be read for lack of
+// permission (so the report can suggest running as root for full coverage).
+type procScan struct {
+	processes      []runningProcess
+	procUnreadable bool // /proc could not be listed; the scan did not run
+	permissionGaps bool // a candidate's maps could not be read (needs root)
+}
+
+// procLayout locates the /proc tree and the injector library name the scan
+// looks for. Tests point procRoot at a fake /proc built under a temp directory.
+type procLayout struct {
+	procRoot    string // /proc
+	injectorLib string // /usr/lib/opentelemetry/injector/libotelinject.so
+}
+
+// systemProcLayout returns the process-scan layout for a real system.
+func systemProcLayout() procLayout {
+	return procLayout{
+		procRoot:    "/proc",
+		injectorLib: "/usr/lib/opentelemetry/injector/libotelinject.so",
+	}
+}
+
+// runtimeMatchers maps a supported runtime to the substrings that identify it
+// in a process's command name or executable path. These mirror the runtimes the
+// injector itself detects and instruments.
+var runtimeMatchers = []struct {
+	runtime string
+	needles []string
+}{
+	{"Java", []string{"java"}},
+	{"Node.js", []string{"node", "nodejs"}},
+	{".NET", []string{"dotnet"}},
+	{"Python", []string{"python"}},
+}
+
+// scanRunningProcesses walks /proc and returns every process running a
+// supported runtime, classified as already-monitored or needing a restart. It
+// skips processes it cannot read (the process exited mid-scan, or its maps are
+// owned by another user and this check is not running as root): the scan is
+// best-effort by design and must never fail the overall check because of an
+// unreadable process it does not own. A permission-denied skip is recorded so
+// the report can advise running as root for full coverage.
+func scanRunningProcesses(l procLayout) procScan {
+	entries, err := os.ReadDir(l.procRoot)
+	if err != nil {
+		return procScan{procUnreadable: true}
+	}
+
+	var scan procScan
+	for _, entry := range entries {
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue // not a PID directory
+		}
+
+		runtime, ok := detectRuntime(l.procRoot, pid)
+		if !ok {
+			continue // not a supported runtime; not our concern
+		}
+
+		mapped, err := injectorMapped(l.procRoot, pid, l.injectorLib)
+		if errors.Is(err, os.ErrPermission) {
+			// The process is a supported runtime, but its maps are owned by
+			// another user and cannot be read without root. Record the gap so
+			// the report can suggest root, and skip classifying this process
+			// rather than mislabel it as needing a restart.
+			scan.permissionGaps = true
+			continue
+		}
+		state := procNeedsRestart
+		if mapped {
+			state = procMonitored
+		}
+		scan.processes = append(scan.processes, runningProcess{
+			pid:     pid,
+			comm:    readComm(l.procRoot, pid),
+			runtime: runtime,
+			state:   state,
+		})
+	}
+
+	sort.Slice(scan.processes, func(i, j int) bool {
+		return scan.processes[i].pid < scan.processes[j].pid
+	})
+	return scan
+}
+
+// detectRuntime reports which supported runtime a process runs, if any, by
+// matching its command name (/proc/<pid>/comm) and its argv[0]
+// (/proc/<pid>/cmdline) against the known runtime needles. This is the simple,
+// documented substring match described in the file header.
+func detectRuntime(procRoot string, pid int) (runtime string, ok bool) {
+	haystack := strings.ToLower(readComm(procRoot, pid))
+	if argv0 := firstCmdlineField(procRoot, pid); argv0 != "" {
+		haystack += "\x00" + strings.ToLower(filepath.Base(argv0))
+	}
+	for _, m := range runtimeMatchers {
+		for _, needle := range m.needles {
+			if strings.Contains(haystack, needle) {
+				return m.runtime, true
+			}
+		}
+	}
+	return "", false
+}
+
+// injectorMapped reports whether the injector library is currently mapped into
+// the process address space, which is the definitive proof that the process
+// started with the injector preloaded and is therefore being instrumented. A
+// permission error is returned to the caller (rather than swallowed) so the scan
+// can distinguish "not mapped" from "could not be read without root".
+func injectorMapped(procRoot string, pid int, injectorLib string) (bool, error) {
+	data, err := os.ReadFile(filepath.Join(procRoot, strconv.Itoa(pid), "maps"))
+	if err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			return false, err
+		}
+		// The process exited mid-scan, or maps is otherwise gone; treat it as
+		// not mapped without flagging a permission gap.
+		return false, nil
+	}
+	return strings.Contains(string(data), injectorLib), nil
+}
+
+// readComm returns the process command name from /proc/<pid>/comm, or an empty
+// string if it cannot be read.
+func readComm(procRoot string, pid int) string {
+	data, err := os.ReadFile(filepath.Join(procRoot, strconv.Itoa(pid), "comm"))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// firstCmdlineField returns argv[0] from /proc/<pid>/cmdline, whose fields are
+// NUL-separated, or an empty string if it cannot be read.
+func firstCmdlineField(procRoot string, pid int) string {
+	data, err := os.ReadFile(filepath.Join(procRoot, strconv.Itoa(pid), "cmdline"))
+	if err != nil {
+		return ""
+	}
+	if i := strings.IndexByte(string(data), 0); i >= 0 {
+		return string(data[:i])
+	}
+	return string(data)
+}
+
+// describeRunningProcesses turns the scan into report lines and reports whether
+// any process needs a restart. It emits one summary line, then one line per
+// process that needs a restart (the actionable set the user asked for), then one
+// line per already-monitored process; when the scan could not read some
+// processes without root it adds a hint to re-run as root. It never fails the
+// overall check: a process that predates the install is a fact for the user to
+// act on, not an installation defect (the caller maps needsRestart to a distinct
+// exit code instead).
+func describeRunningProcesses(scan procScan) (results []checkResult, needsRestart bool) {
+	if scan.procUnreadable {
+		return []checkResult{{statusInfo,
+			"running-process scan skipped: /proc is not readable on this system"}}, false
+	}
+
+	var monitored, needRestart []runningProcess
+	for _, p := range scan.processes {
+		if p.state == procMonitored {
+			monitored = append(monitored, p)
+		} else {
+			needRestart = append(needRestart, p)
+		}
+	}
+
+	results = []checkResult{{statusInfo, fmt.Sprintf(
+		"running processes on supported runtimes: %d monitored, %d not monitored (restart required). "+
+			"A mapped injector proves the injector ran, not that the SDK is healthy; runtime detection is a best-effort name match.",
+		len(monitored), len(needRestart))}}
+
+	for _, p := range needRestart {
+		results = append(results, checkResult{statusWarn, fmt.Sprintf(
+			"NOT monitored: pid %d (%s, %s) started before install; restart it to instrument (e.g. systemctl restart the owning unit)",
+			p.pid, p.comm, p.runtime)})
+	}
+	for _, p := range monitored {
+		results = append(results, checkResult{statusOK, fmt.Sprintf(
+			"monitored: pid %d (%s, %s)", p.pid, p.comm, p.runtime)})
+	}
+
+	if scan.permissionGaps {
+		results = append(results, checkResult{statusInfo,
+			"some processes could not be read; run as root for full coverage"})
+	}
+
+	return results, len(needRestart) > 0
+}

--- a/cmd/otel-instrumentation-check/processes_test.go
+++ b/cmd/otel-instrumentation-check/processes_test.go
@@ -1,0 +1,119 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeProc writes a minimal /proc/<pid> directory: comm, cmdline (NUL-joined),
+// and maps. It lets the scan run against a controlled process table without a
+// real system.
+func fakeProc(t *testing.T, procRoot string, pid int, comm string, argv []string, maps string) {
+	t.Helper()
+	dir := filepath.Join(procRoot, strconv.Itoa(pid))
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "comm"), []byte(comm+"\n"), 0o644))
+
+	var cmdline []byte
+	for _, a := range argv {
+		cmdline = append(cmdline, []byte(a)...)
+		cmdline = append(cmdline, 0)
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cmdline"), cmdline, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "maps"), []byte(maps), 0o644))
+}
+
+func TestScanClassifiesMonitoredAndNeedsRestart(t *testing.T) {
+	procRoot := t.TempDir()
+	injectorLib := "/usr/lib/opentelemetry/injector/libotelinject.so"
+
+	// A Java process started after install: injector mapped -> monitored.
+	fakeProc(t, procRoot, 100, "java", []string{"/usr/bin/java", "-jar", "app.jar"},
+		"7f000000-7f001000 r-xp 00000000 00:00 0 "+injectorLib+"\n")
+	// A Python process started before install: injector not mapped -> restart.
+	fakeProc(t, procRoot, 200, "python3", []string{"/usr/bin/python3", "server.py"},
+		"7f000000-7f001000 r-xp 00000000 00:00 0 /usr/lib/libc.so.6\n")
+	// A non-runtime process: ignored entirely.
+	fakeProc(t, procRoot, 300, "bash", []string{"/bin/bash"}, "")
+
+	scan := scanRunningProcesses(procLayout{procRoot: procRoot, injectorLib: injectorLib})
+	require.False(t, scan.procUnreadable)
+	require.False(t, scan.permissionGaps)
+	require.Len(t, scan.processes, 2, "only the two supported-runtime processes are considered")
+
+	byPID := map[int]runningProcess{}
+	for _, p := range scan.processes {
+		byPID[p.pid] = p
+	}
+	require.Equal(t, procMonitored, byPID[100].state)
+	require.Equal(t, "Java", byPID[100].runtime)
+	require.Equal(t, procNeedsRestart, byPID[200].state)
+	require.Equal(t, "Python", byPID[200].runtime)
+}
+
+func TestDescribeRunningProcessesReportsBothSetsAndSignalsRestart(t *testing.T) {
+	scan := procScan{processes: []runningProcess{
+		{pid: 100, comm: "java", runtime: "Java", state: procMonitored},
+		{pid: 200, comm: "python3", runtime: "Python", state: procNeedsRestart},
+	}}
+	results, needsRestart := describeRunningProcesses(scan)
+	require.True(t, needsRestart, "a process needing a restart must be signaled to the caller")
+	msg := messages(results)
+	require.Contains(t, msg, "1 monitored, 1 not monitored")
+	require.Contains(t, msg, "NOT monitored: pid 200")
+	require.Contains(t, msg, "restart it to instrument")
+	require.Contains(t, msg, "monitored: pid 100")
+}
+
+func TestDescribeRunningProcessesAllMonitoredDoesNotSignalRestart(t *testing.T) {
+	scan := procScan{processes: []runningProcess{
+		{pid: 100, comm: "java", runtime: "Java", state: procMonitored},
+	}}
+	_, needsRestart := describeRunningProcesses(scan)
+	require.False(t, needsRestart, "when every process is monitored, no restart is needed")
+}
+
+func TestScanSkipsUnreadableProcAndDoesNotPanic(t *testing.T) {
+	scan := scanRunningProcesses(procLayout{procRoot: "/nonexistent-proc", injectorLib: "x"})
+	require.True(t, scan.procUnreadable)
+	require.Nil(t, scan.processes)
+	results, needsRestart := describeRunningProcesses(scan)
+	require.False(t, needsRestart)
+	require.Contains(t, messages(results), "scan skipped")
+}
+
+func TestPermissionGapAddsRunAsRootHint(t *testing.T) {
+	// A permission gap is reported to the user as a hint to re-run as root, and
+	// it must not, on its own, count as a needs-restart.
+	scan := procScan{permissionGaps: true}
+	results, needsRestart := describeRunningProcesses(scan)
+	require.False(t, needsRestart)
+	require.Contains(t, messages(results), "run as root for full coverage")
+}
+
+// TestUnreadableMapsFileIsNotAPermissionGap pins that a process whose maps file
+// is simply gone (the process exited mid-scan) is treated as not monitored,
+// without raising the run-as-root hint reserved for true permission denials.
+func TestUnreadableMapsFileIsNotAPermissionGap(t *testing.T) {
+	procRoot := t.TempDir()
+	injectorLib := "/usr/lib/opentelemetry/injector/libotelinject.so"
+
+	// Build a supported-runtime process but leave out its maps file so reading
+	// it fails with a not-exist error rather than a permission error.
+	dir := filepath.Join(procRoot, "400")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "comm"), []byte("node\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cmdline"), []byte("node\x00"), 0o644))
+
+	scan := scanRunningProcesses(procLayout{procRoot: procRoot, injectorLib: injectorLib})
+	require.False(t, scan.permissionGaps, "a missing maps file is not a permission denial")
+	require.Len(t, scan.processes, 1)
+	require.Equal(t, procNeedsRestart, scan.processes[0].state)
+}

--- a/docs/design/integration-test-plan.md
+++ b/docs/design/integration-test-plan.md
@@ -162,11 +162,12 @@ The scenarios run inside the `integration-test-deb-<language>` targets.
 ### 9. Post-install sanity check
 
 Validate the `otel-instrumentation-check` command shipped in the injector package, which confirms the injector is active and the language agents are wired up without a running application or an OTLP receiver.
+It also scans the processes running now and reports which are already instrumented and which started before install and must be restarted, exiting `3` (distinct from `0`) when a restart is needed so a provisioning script can act on it.
 
 | Scenario | Assertion |
 |----------|-----------|
-| Full install, then run the check | Exit 0, reports the injector active and at least one language agent registered |
-| Injector alone (no language agent), then run the check | Exit non-zero, reports that no language agents are registered |
+| Full install, then run the check | Exit 0 or 3 (both mean the install is correct; 3 signals a running process must be restarted), reports the injector active, at least one language agent registered, and the running-process scan summary |
+| Injector alone (no language agent), then run the check | Exit 1, reports that no language agents are registered |
 
 **Implementation:** Install packages in a container and run the command, asserting on its exit code and output.
 Implemented in `packaging/tests/lifecycle/sanitycheck_test.go`.

--- a/docs/design/integration-test-plan.md
+++ b/docs/design/integration-test-plan.md
@@ -159,6 +159,18 @@ This proves the whole declarative chain: the shipped file is valid, the `${VAR}`
 Declarative runs assert traces only: under `OTEL_CONFIG_FILE` the SDKs ignore the env-var schedule tuning the images set, so metrics follow the default 60-second cadence.
 The scenarios run inside the `integration-test-deb-<language>` targets.
 
+### 9. Post-install sanity check
+
+Validate the `otel-instrumentation-check` command shipped in the injector package, which confirms the injector is active and the language agents are wired up without a running application or an OTLP receiver.
+
+| Scenario | Assertion |
+|----------|-----------|
+| Full install, then run the check | Exit 0, reports the injector active and at least one language agent registered |
+| Injector alone (no language agent), then run the check | Exit non-zero, reports that no language agents are registered |
+
+**Implementation:** Install packages in a container and run the command, asserting on its exit code and output.
+Implemented in `packaging/tests/lifecycle/sanitycheck_test.go`.
+
 ## Test infrastructure
 
 ### Package metadata and contents tests

--- a/docs/design/packages-meta-architecture.md
+++ b/docs/design/packages-meta-architecture.md
@@ -93,6 +93,9 @@ See [Vendor override](#vendor-override) for the recipe and user experience.
 All paths follow the [Filesystem Hierarchy Standard](https://refspecs.linuxfoundation.org/FHS_3.0/fhs-3.0.html) (FHS).
 
 ```
+/usr/bin/
+└── otel-instrumentation-check    (post-install sanity check; installed by the injector package)
+
 /usr/lib/opentelemetry/
 ├── injector/
 │   └── libotelinject.so
@@ -154,6 +157,7 @@ At runtime, the library inspects each process to determine if it is a Java, Node
 | Path | Description |
 |------|-------------|
 | `/usr/lib/opentelemetry/injector/libotelinject.so` | Injector shared library (per-arch) |
+| `/usr/bin/otel-instrumentation-check` | Post-install sanity check for the injector and language agents (per-arch) |
 | `/etc/opentelemetry/injector/injector.conf` | Main configuration file |
 | `/etc/opentelemetry/injector/default_env.conf` | Default `OTEL_*` environment variables for all agents |
 | `/etc/opentelemetry/injector/conf.d/` | Drop-in directory for language agent paths (empty until language packages are installed) |
@@ -396,7 +400,7 @@ This is critical for `Conflicts`/`Replaces` to work correctly.
 
 | Package | Owns |
 |---------|------|
-| `opentelemetry-injector` | `/usr/lib/opentelemetry/injector/`, `/etc/opentelemetry/injector/injector.conf`, `/etc/opentelemetry/injector/default_env.conf`, `/etc/opentelemetry/injector/conf.d/` (directory only) |
+| `opentelemetry-injector` | `/usr/lib/opentelemetry/injector/`, `/usr/bin/otel-instrumentation-check`, `/etc/opentelemetry/injector/injector.conf`, `/etc/opentelemetry/injector/default_env.conf`, `/etc/opentelemetry/injector/conf.d/` (directory only) |
 | `opentelemetry-java-autoinstrumentation` | `/usr/lib/opentelemetry/java/`, `/etc/opentelemetry/injector/conf.d/java.conf`, `/etc/opentelemetry/java/` |
 | `opentelemetry-nodejs-autoinstrumentation` | `/usr/lib/opentelemetry/nodejs/`, `/etc/opentelemetry/injector/conf.d/nodejs.conf`, `/etc/opentelemetry/nodejs/` |
 | `opentelemetry-dotnet-autoinstrumentation` | `/usr/lib/opentelemetry/dotnet/`, `/etc/opentelemetry/injector/conf.d/dotnet.conf`, `/etc/opentelemetry/dotnet/` |

--- a/packaging/builder/builder.go
+++ b/packaging/builder/builder.go
@@ -39,6 +39,11 @@ type Config struct {
 	// builder only assembles packages; the binary is cross-compiled upfront
 	// (see the otel-config-check Makefile target).
 	ConfigCheckBinary string
+	// SanityCheckBinary is the path to a prebuilt otel-instrumentation-check
+	// binary for the target architecture, shipped inside the injector package.
+	// Like ConfigCheckBinary, it is cross-compiled upfront (see the
+	// otel-instrumentation-check Makefile target).
+	SanityCheckBinary string
 }
 
 // Relations declares a package's relationships to other packages.

--- a/packaging/builder/components.go
+++ b/packaging/builder/components.go
@@ -123,6 +123,17 @@ const (
 )
 
 func injectorContents(cfg Config) (files.Contents, func(), error) {
+	// otel-instrumentation-check ships in the injector package so the post-install
+	// sanity check is present whenever the injector is (the metapackage hard-depends
+	// on it). It is cross-compiled before the package build (Makefile target
+	// otel-instrumentation-check); fail fast before the injector download when it is
+	// missing.
+	if _, err := os.Stat(cfg.SanityCheckBinary); err != nil {
+		return nil, func() {}, fmt.Errorf(
+			"otel-instrumentation-check binary not found at %q: build it with `make otel-instrumentation-check` or pass -sanity-check-binary: %w",
+			cfg.SanityCheckBinary, err)
+	}
+
 	staging, err := os.MkdirTemp("", "otel-injector-*")
 	if err != nil {
 		return nil, nil, err
@@ -143,6 +154,7 @@ func injectorContents(cfg Config) (files.Contents, func(), error) {
 
 	return files.Contents{
 		regularFile(soPath, injectorInstallDir+"/libotelinject.so", 0o755),
+		regularFile(cfg.SanityCheckBinary, "/usr/bin/otel-instrumentation-check", 0o755),
 		configFile(filepath.Join(commonDir, "injector", "injector.conf"), injectorConfigDir+"/injector.conf"),
 		configFile(filepath.Join(commonDir, "injector", "default_env.conf"), injectorConfigDir+"/default_env.conf"),
 		directory(injectorConfigDir + "/conf.d"),

--- a/packaging/builder/opentelemetry-packaging.spec.tmpl
+++ b/packaging/builder/opentelemetry-packaging.spec.tmpl
@@ -131,6 +131,7 @@ export GOFLAGS="-mod=vendor"
 export GOTOOLCHAIN=auto
 go build -trimpath -o build/bin/build-spec ./cmd/build-spec/rpm
 go build -trimpath -o build/bin/otel-config-check ./cmd/otel-config-check
+go build -trimpath -o build/bin/otel-instrumentation-check ./cmd/otel-instrumentation-check
 
 %install
 # The payload is staged by the same builder that produces the nfpm packages, and
@@ -146,7 +147,8 @@ stage() {
         -component "$1" \
         -version %{version} \
         -arch %{otel_arch} \
-        -config-check-binary build/bin/otel-config-check
+        -config-check-binary build/bin/otel-config-check \
+        -sanity-check-binary build/bin/otel-instrumentation-check
 }
 
 for component in {{ .UnguardedComponents }}; do

--- a/packaging/common/injector/README.md
+++ b/packaging/common/injector/README.md
@@ -8,6 +8,19 @@ It enables zero-code instrumentation for applications running on Linux systems.
 The injector library (`libotelinject.so`) is loaded via `/etc/ld.so.preload` into every process.
 It detects the runtime (Java, Node.js, .NET, Python) and injects the appropriate OpenTelemetry auto-instrumentation agent.
 
+## Verifying the installation
+
+Run the bundled sanity check to confirm the injector is active and the installed language agents are wired up:
+
+```sh
+otel-instrumentation-check
+```
+
+The injector is a preloaded library rather than a service, so there is no daemon status to query.
+Instead, the check reads the same files a newly started process would (`/etc/ld.so.preload`, the `conf.d/` drop-ins, and `default_env.conf`) and reports, per language, whether the registered agent is present on disk.
+It needs no running application and no OTLP receiver, and exits non-zero if the injector is not active or a registered agent is missing.
+It also reports where telemetry is configured to go, so a missing backend is not mistaken for a broken install.
+
 ## Configuration
 
 The injector is configured via `/etc/opentelemetry/injector/injector.conf`.
@@ -36,6 +49,7 @@ Use this to configure common settings like:
 ## Files
 
 - `/usr/lib/opentelemetry/injector/libotelinject.so`: The injector shared library
+- `/usr/bin/otel-instrumentation-check`: Post-install sanity check for the injector and language agents
 - `/etc/opentelemetry/injector/injector.conf`: Main configuration file
 - `/etc/opentelemetry/injector/default_env.conf`: Default environment variables
 - `/etc/opentelemetry/injector/conf.d/`: Drop-in configuration directory

--- a/packaging/common/injector/opentelemetry-injector.8.tmpl
+++ b/packaging/common/injector/opentelemetry-injector.8.tmpl
@@ -23,6 +23,24 @@ up, run
 after installation. It inspects the preload and configuration files a new
 process would read and reports the result; it needs no running application and
 no OTLP receiver.
+.PP
+The check also scans the processes running now and reports which are already
+instrumented and which started before the package was installed and so must be
+restarted to pick it up, detected by testing whether the injector library is
+mapped into each process via /proc/<pid>/maps. Reading another user's process
+requires root, so run the check as root for full coverage. A mapped injector
+proves the injector ran in the process, not that the language SDK finished
+attaching, so this is the best signal available without a running application,
+not a guarantee. Runtime detection is a best-effort match on the process command
+name.
+.PP
+.B otel-instrumentation-check
+exits 0 when the injector is active, an agent is present, and no running process
+needs a restart; 1 when an installation problem is found; 2 on a usage error;
+and 3 when the installation is correct but one or more already-running processes
+must be restarted before they are instrumented. Exit code 3 is distinct from 0
+so a provisioning script can restart the affected units without treating the
+situation as an installation failure.
 .SH FILES
 .TP
 .B /usr/lib/opentelemetry/injector/libotelinject.so

--- a/packaging/common/injector/opentelemetry-injector.8.tmpl
+++ b/packaging/common/injector/opentelemetry-injector.8.tmpl
@@ -16,10 +16,21 @@ Node.js, .NET, and Python runtimes.
 When a process starts, the injector library detects the runtime environment
 and loads the appropriate OpenTelemetry agent to enable automatic telemetry
 collection without code changes.
+.PP
+To confirm the injector is active and the installed language agents are wired
+up, run
+.B otel-instrumentation-check
+after installation. It inspects the preload and configuration files a new
+process would read and reports the result; it needs no running application and
+no OTLP receiver.
 .SH FILES
 .TP
 .B /usr/lib/opentelemetry/injector/libotelinject.so
 The injector shared library that is preloaded into processes.
+.TP
+.B /usr/bin/otel-instrumentation-check
+Post-install sanity check that verifies the injector is active and the
+registered language agents are present.
 .TP
 .B /etc/opentelemetry/injector/injector.conf
 Main configuration file specifying the default environment variables path

--- a/packaging/tests/lifecycle/lifecycle_test.go
+++ b/packaging/tests/lifecycle/lifecycle_test.go
@@ -26,6 +26,7 @@ import (
 const (
 	preloadPath      = "/etc/ld.so.preload"
 	injectorLib      = "/usr/lib/opentelemetry/injector/libotelinject.so"
+	sanityCheckBin   = "/usr/bin/otel-instrumentation-check"
 	javaAgentJar     = "/usr/lib/opentelemetry/java/opentelemetry-javaagent.jar"
 	injectorConfDir  = "/etc/opentelemetry/injector"
 	injectorConfPath = injectorConfDir + "/injector.conf"
@@ -67,10 +68,12 @@ type scenario struct {
 func TestLifecycle(t *testing.T) {
 	ctx := context.Background()
 
-	scenarios := make([]scenario, 0, len(preloadScenarios)+len(configScenarios)+len(installScenarios))
+	scenarios := make([]scenario, 0,
+		len(preloadScenarios)+len(configScenarios)+len(installScenarios)+len(sanityCheckScenarios))
 	scenarios = append(scenarios, preloadScenarios...)
 	scenarios = append(scenarios, configScenarios...)
 	scenarios = append(scenarios, installScenarios...)
+	scenarios = append(scenarios, sanityCheckScenarios...)
 
 	byFormat := map[string][]target{}
 	for _, tg := range matrix {

--- a/packaging/tests/lifecycle/sanitycheck_test.go
+++ b/packaging/tests/lifecycle/sanitycheck_test.go
@@ -25,11 +25,18 @@ var sanityCheckScenarios = []scenario{
 			h.install(t, ctx, "opentelemetry")
 
 			code, output := testutil.ExecInContainer(t, ctx, h.container, sanityCheckBin)
-			assert.Equal(t, 0, code, "the check must pass on a full install.\n\nOutput:\n%s", output)
-			assert.Contains(t, output, "Result: PASS", output)
+			// A correct installation exits 0 (no already-running process needs a
+			// restart) or 3 (the install is correct, but a process that started
+			// before install must be restarted to be instrumented). Both mean the
+			// installation itself is wired up; only 1 (install problem) and 2
+			// (usage error) are failures here.
+			assert.Contains(t, []int{0, 3}, code,
+				"the check must report a correct install (exit 0 or 3).\n\nOutput:\n%s", output)
 			assert.Contains(t, output, "injector active", output)
 			assert.GreaterOrEqual(t, strings.Count(output, "agent registered"), 1,
 				"at least one language agent should be reported as registered")
+			assert.Contains(t, output, "running processes on supported runtimes",
+				"the running-process scan must report its summary")
 		},
 	},
 	{

--- a/packaging/tests/lifecycle/sanitycheck_test.go
+++ b/packaging/tests/lifecycle/sanitycheck_test.go
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package lifecycle
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-packaging/testutil"
+)
+
+// sanityCheckScenarios exercise the otel-instrumentation-check command shipped
+// in the injector package: it must report a healthy install after a full
+// installation and fail when the injector is present but no language agent is
+// registered. It needs no OTLP receiver and no running application.
+var sanityCheckScenarios = []scenario{
+	{
+		name: "sanity-check-passes-on-full-install",
+		run: func(t *testing.T, ctx context.Context, h *harness) {
+			h.install(t, ctx, "opentelemetry")
+
+			code, output := testutil.ExecInContainer(t, ctx, h.container, sanityCheckBin)
+			assert.Equal(t, 0, code, "the check must pass on a full install.\n\nOutput:\n%s", output)
+			assert.Contains(t, output, "Result: PASS", output)
+			assert.Contains(t, output, "injector active", output)
+			assert.GreaterOrEqual(t, strings.Count(output, "agent registered"), 1,
+				"at least one language agent should be reported as registered")
+		},
+	},
+	{
+		name: "sanity-check-fails-without-language-agents",
+		run: func(t *testing.T, ctx context.Context, h *harness) {
+			h.install(t, ctx, "opentelemetry-injector")
+
+			code, output := testutil.ExecInContainer(t, ctx, h.container, sanityCheckBin)
+			require.Equal(t, 1, code, "the check must fail when no language agent is registered.\n\nOutput:\n%s", output)
+			assert.Contains(t, output, "no language agents registered", output)
+		},
+	},
+}


### PR DESCRIPTION
Fixes #61.

## What

Adds `otel-instrumentation-check`, a lightweight command that answers two questions about auto-instrumentation on a host, **without a running OTLP receiver and without restarting an application**. It ships in the `opentelemetry-injector` package at `/usr/bin/otel-instrumentation-check`.

1. **Is this machine set up so newly started processes will be instrumented?** A static, machine-wide check that reads the same files a newly started process would consult.
2. **Of the processes running right now, which are already instrumented and which started before the package was installed and so must be restarted to pick it up?** A per-process runtime scan.

```console
$ otel-instrumentation-check
OpenTelemetry auto-instrumentation post-install check

[ ok ] injector library present: /usr/lib/opentelemetry/injector/libotelinject.so
[ ok ] injector active in /etc/ld.so.preload
[ ok ] Python agent registered (python.conf): /usr/lib/opentelemetry/python/glibc
[info] telemetry destination: http://localhost:4317 (gRPC) or http://localhost:4318 (HTTP), the default. No OTLP receiver is needed for this check, but one must be reachable for telemetry to arrive.
[info] running processes on supported runtimes: 1 monitored, 1 not monitored (restart required). A mapped injector proves the injector ran, not that the SDK is healthy; runtime detection is a best-effort name match.
[warn] NOT monitored: pid 3120 (python3, Python) started before install; restart it to instrument (e.g. systemctl restart the owning unit)
[ ok ] monitored: pid 4711 (java, Java)

Result: ACTION NEEDED. The injector is active, but some already-running processes started before install and must be restarted to be instrumented; see the [warn] items above.
```

## Why this shape

### Static machine-wide check

Answering @atoulme's question on the issue ("Is a collector required for this? Can we check the collector status according to systemd?"): no collector is required, and there is deliberately no systemd check. The injector is an `LD_PRELOAD` library, not a daemon, so there is no service whose status could report "instrumentation is on". The check instead reads the exact files a newly started process would consult and reports what that process would pick up:

- **Injector active**: `/etc/ld.so.preload` lists `libotelinject.so` (matched as a whitespace-separated field, the same way the postinstall script and the dynamic linker treat the file), and the library exists on disk.
- **Language agents registered**: each `conf.d/*.conf` drop-in is parsed and the agent path it registers is checked for existence (prefix keys resolve the `glibc/` subdirectory, matching the injector).
- **Telemetry destination**: reports `OTEL_CONFIG_FILE` (declarative config) or the `OTEL_EXPORTER_OTLP_ENDPOINT` (falling back to the documented default), so a missing backend is never mistaken for a broken install.

### Per-process runtime scan

The static check confirms the install is correct, but it cannot tell you whether the services **running right now** are instrumented: `/etc/ld.so.preload` is consulted only at process startup, so a process that started before the package was installed is never instrumented until it restarts. This is the end-user question @mmanciop raised on the issue and the PR ("Which applications are now being monitored and which not, and have to be restarted to be monitored"), so the check now scans the running processes too.

For each running process on a supported runtime (Java, Node.js, .NET, Python), the scan reads `/proc/<pid>/maps` and tests whether `libotelinject.so` is mapped into it. That mapping is the ground-truth signal that the process went through the injector at startup:

- injector mapped -> the process started after install and is being instrumented;
- injector not mapped -> the process started before install and must be restarted (for example, `systemctl restart` the owning unit).

The scan is best-effort by design: it needs no restart, no OTLP receiver, and no injector logs, and it never fails the overall check because of a process it cannot read. Reading another user's `/proc/<pid>/maps` requires root, so when the scan cannot read a process it skips it and prints a hint to run as root for full coverage.

Two limitations are documented in the code, the report output, the README, and the man page:

- a mapped `libotelinject.so` proves the **injector ran** in the process, not that the language **SDK finished attaching and is healthy** (the injector could run and the agent still fail to load), so the running-process result is the best signal available without a running application, not a guarantee; and
- runtime detection is a simple substring match on the process command name and `argv[0]`, which can misfire on an unrelated wrapper name.

A definitive per-process answer would need a cross-language SDK health mechanism that does not exist in OpenTelemetry yet; this scan is the best available proxy today.

### Exit codes

- `0` the injector is active, at least one language agent is present, and no running process needs a restart;
- `1` an installation problem was found;
- `2` usage error;
- `3` the installation is correct but one or more already-running processes started before install and must be restarted to be instrumented.

Code `3` is distinct from `0` so a provisioning script can detect the "needs restart" case and restart the affected `systemd` units without treating it as an installation failure. An installation problem (`1`) outranks the needs-restart signal.

## Changes

- `cmd/otel-instrumentation-check/` - the command plus unit tests (temp-dir and fake-`/proc` based, mirroring `otel-config-check`): the static install check and the `/proc/<pid>/maps` running-process scan.
- Build wiring: cross-compiled like `otel-config-check` (`make otel-instrumentation-check`), embedded in the injector package by `packaging/builder`.
- `packaging/tests/lifecycle/sanitycheck_test.go` - container tests: a correct install exits `0` or `3` (both mean the install is wired up) and reports the running-process scan summary; the injector installed with no language agent exits `1`.
- Docs: main README, injector README and man page, CONTRIBUTING repository layout, the architecture design doc (filesystem layout, injector contents, file-ownership table), and the integration test plan - all updated to cover the running-process scan, exit code `3`, the run-as-root hint, and the documented limitations.

## Testing

- `make go-unit-tests` (adds the new package's suite, including the running-process scan tests)
- `go vet ./...` and `gofmt` clean
- Built the injector `.deb` locally and confirmed `/usr/bin/otel-instrumentation-check` is embedded (mode 0755)
- Container lifecycle tests added under `integration-test-{deb,rpm}-lifecycle`
