### PR TITLE
Verify .NET agent checksum against upstream checksums.txt

### DIFF
--- a/packaging/builder/download.go
+++ b/packaging/builder/download.go
@@ -7,6 +7,8 @@ import (
 	"archive/zip"
 	"bufio"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -83,6 +85,57 @@ func downloadFile(url, dest string) (retErr error) {
 	}()
 	_, retErr = io.Copy(f, resp.Body)
 	return retErr
+}
+
+// fetchChecksums downloads a sha256sum(1)-style manifest (lines of
+// "<hex digest>  <filename>", optionally with a "*" binary-mode marker before
+// the filename) and returns it as a map from filename to lowercase hex digest.
+func fetchChecksums(url string) (map[string]string, error) {
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("fetching %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetching %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	sums := make(map[string]string)
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 {
+			continue
+		}
+		digest := strings.ToLower(fields[0])
+		name := strings.TrimPrefix(fields[len(fields)-1], "*")
+		sums[name] = digest
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading %s: %w", url, err)
+	}
+	return sums, nil
+}
+
+// verifyFileSHA256 hashes the file at path and returns an error if it does
+// not match the expected lowercase hex digest.
+func verifyFileSHA256(path, want string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("hashing %s: %w", path, err)
+	}
+
+	got := hex.EncodeToString(h.Sum(nil))
+	if got != strings.ToLower(want) {
+		return fmt.Errorf("checksum mismatch for %s: got %s, want %s", path, got, want)
+	}
+	return nil
 }
 
 // downloadInjector fetches libotelinject.so from GitHub releases.
@@ -182,6 +235,14 @@ func downloadDotnetAgent(cfg Config, destDir string) error {
 
 	baseURL := "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download"
 
+	// Every release publishes a checksums.txt alongside the archives; verify
+	// the downloaded artifact against it before extracting.
+	checksumsURL := fmt.Sprintf("%s/%s/checksums.txt", baseURL, tag)
+	checksums, err := fetchChecksums(checksumsURL)
+	if err != nil {
+		return fmt.Errorf("fetching checksums: %w", err)
+	}
+
 	// Download and extract glibc archive into a glibc/ subdirectory.
 	// The injector expects all glibc files (managed DLLs and native library)
 	// under <prefix>/glibc/.
@@ -195,6 +256,13 @@ func downloadDotnetAgent(cfg Config, destDir string) error {
 	glibcZipPath := glibcZip.Name()
 	defer os.Remove(glibcZipPath)
 	if err := downloadFile(glibcURL, glibcZipPath); err != nil {
+		return err
+	}
+	want, ok := checksums[glibcPkg]
+	if !ok {
+		return fmt.Errorf("no checksum published for %s in %s", glibcPkg, checksumsURL)
+	}
+	if err := verifyFileSHA256(glibcZipPath, want); err != nil {
 		return err
 	}
 	glibcDest := filepath.Join(destDir, "glibc")

--- a/packaging/builder/download_test.go
+++ b/packaging/builder/download_test.go
@@ -1,0 +1,95 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package builder
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFetchChecksums(t *testing.T) {
+	body := "" +
+		"ef1b39f1379db463533f97ab5a1a3ebcb2bf92b219eed0aff8faf3a899c1ae9  opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip\n" +
+		"a0c52a23366091d8cd8d62424806a6a96734aee869ee4da2fc21f7925fae538  opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip\n" +
+		"\n" +
+		"DEADBEEF00000000000000000000000000000000000000000000000000000  *binary-mode-file.zip\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	sums, err := fetchChecksums(srv.URL + "/checksums.txt")
+	if err != nil {
+		t.Fatalf("fetchChecksums: %v", err)
+	}
+
+	want := map[string]string{
+		"opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip": "ef1b39f1379db463533f97ab5a1a3ebcb2bf92b219eed0aff8faf3a899c1ae9",
+		"opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip":   "a0c52a23366091d8cd8d62424806a6a96734aee869ee4da2fc21f7925fae538",
+		"binary-mode-file.zip": "deadbeef00000000000000000000000000000000000000000000000000000",
+	}
+	if len(sums) != len(want) {
+		t.Fatalf("fetchChecksums returned %d entries, want %d: %v", len(sums), len(want), sums)
+	}
+	for name, digest := range want {
+		if sums[name] != digest {
+			t.Errorf("checksum for %s = %q, want %q", name, sums[name], digest)
+		}
+	}
+}
+
+func TestFetchChecksumsHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	if _, err := fetchChecksums(srv.URL + "/checksums.txt"); err == nil {
+		t.Fatal("fetchChecksums: expected error on HTTP 404, got nil")
+	}
+}
+
+func TestVerifyFileSHA256(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "artifact.bin")
+	content := []byte("hello opentelemetry")
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("writing test file: %v", err)
+	}
+
+	sum := sha256.Sum256(content)
+	digest := hex.EncodeToString(sum[:])
+
+	t.Run("match", func(t *testing.T) {
+		if err := verifyFileSHA256(path, digest); err != nil {
+			t.Errorf("verifyFileSHA256: %v", err)
+		}
+	})
+
+	t.Run("match is case-insensitive", func(t *testing.T) {
+		if err := verifyFileSHA256(path, strings.ToUpper(digest)); err != nil {
+			t.Errorf("verifyFileSHA256: %v", err)
+		}
+	})
+
+	t.Run("mismatch", func(t *testing.T) {
+		bogus := "0000000000000000000000000000000000000000000000000000000000000"
+		if err := verifyFileSHA256(path, bogus); err == nil {
+			t.Error("verifyFileSHA256: expected error on checksum mismatch, got nil")
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		if err := verifyFileSHA256(filepath.Join(dir, "missing.bin"), digest); err == nil {
+			t.Error("verifyFileSHA256: expected error for missing file, got nil")
+		}
+	})
+}


### PR DESCRIPTION
The build downloaded the glibc archive from GitHub releases with no integrity check beyond TLS. Every release publishes a checksums.txt alongside the archives, so fetch it and verify the downloaded zip's SHA-256 before extraction.