### PR TITLE
Track the minimum supported Python and keep the sitecustomize gate in sync

### DIFF
--- a/.github/scripts/check-minimum-python-version.sh
+++ b/.github/scripts/check-minimum-python-version.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Keep the sitecustomize.py version gate in sync with the strictest
+# Requires-Python across the distributions that actually ship.
+#
+# Usage: check-minimum-python-version.sh [--check|--write]
+#
+#   --check (the default) fails when the gate differs from the derived floor.
+#   --write rewrites the gate to the derived floor.
+#
+# Environment:
+#
+#   MINIMUM_PYTHON  Interpreter that derives the floor (default: python3.10).
+#   BUILD_DIR       Scratch directory for the venv and the payload
+#                   (default: build/ at the repository root, removed by
+#                   "make clean").
+#
+# The PyPI pins (excluding the vendored source lines) are installed with
+# pip install --target into a throwaway payload directory, the same way
+# packaging/builder/download.go assembles the payload for the DEB and the RPM,
+# and sync_minimum_python_version.py enumerates only that directory. A
+# virtualenv would additionally contain pip and setuptools from "python -m venv"
+# plus the tool's own tomli, none of which ship; since the floor is a maximum, a
+# non-shipped distribution can only raise it, which would mask a floor that
+# should drop while the check still reported "in sync".
+#
+# The vendored floor is read straight from each vendor pyproject.toml via
+# --vendor-dir, so the vendored source does not need to be built for the check.
+#
+# The venv that runs the tool is built with the minimum supported interpreter
+# (MINIMUM_PYTHON, the current 3.x floor) on purpose: its pip must resolve the
+# payload's transitive dependencies the way it would on that floor, so a newer
+# release of a transitive dependency that raised its own Requires-Python does
+# not inflate the derived floor above what actually runs on the minimum
+# interpreter. tomli is the tomllib backport the tool falls back to under
+# Python 3.10 (tomllib is standard library from 3.11).
+
+set -euo pipefail
+
+MODE="${1:---check}"
+case "${MODE}" in
+    --check | --write) ;;
+    *)
+        echo "usage: $(basename "$0") [--check|--write]" >&2
+        exit 2
+        ;;
+esac
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PYTHON_DIR="${REPO_ROOT}/packaging/common/python"
+MINIMUM_PYTHON="${MINIMUM_PYTHON:-python3.10}"
+BUILD_DIR="${BUILD_DIR:-${REPO_ROOT}/build}"
+VENV_DIR="${BUILD_DIR}/minimum-python-version-venv"
+PAYLOAD_DIR="${BUILD_DIR}/minimum-python-version-payload"
+
+if ! command -v "${MINIMUM_PYTHON}" > /dev/null 2>&1; then
+    echo "error: ${MINIMUM_PYTHON} is not installed. The floor must be derived" \
+        "with the minimum supported interpreter so that pip resolves" \
+        "transitive dependencies the way it does on that floor. Install it, or" \
+        "set MINIMUM_PYTHON to the interpreter for the current floor." >&2
+    exit 1
+fi
+
+"${MINIMUM_PYTHON}" -m venv "${VENV_DIR}"
+"${VENV_DIR}/bin/pip" install --quiet packaging tomli
+
+rm -rf "${PAYLOAD_DIR}"
+grep -v '^\./vendor/' "${PYTHON_DIR}/requirements.txt" \
+    | "${VENV_DIR}/bin/pip" install --quiet \
+        --target "${PAYLOAD_DIR}" -r /dev/stdin
+
+"${VENV_DIR}/bin/python" "${PYTHON_DIR}/sync_minimum_python_version.py" \
+    "${MODE}" \
+    --payload-dir "${PAYLOAD_DIR}" \
+    --vendor-dir "${PYTHON_DIR}/vendor" \
+    --sitecustomize "${PYTHON_DIR}/sitecustomize.py"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,14 @@ jobs:
       - name: Run the vendored pyproto exporter test suites
         run: make pyproto-unit-tests
 
+      - name: Set up the minimum supported Python for the version-gate check
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.10"
+
+      - name: Check the sitecustomize minimum Python version is in sync with the bundled distributions
+        run: make check-minimum-python-version
+
   sitecustomize-compatibility-tests:
     runs-on: ubuntu-24.04
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ make rpm-rebuild-container     # Rebuild the SRPM into binary RPMs the way COPR 
 
 make go-unit-tests             # Go command unit tests (otel-config-check)
 make python-unit-tests         # sitecustomize.py unit tests (throwaway venv, no containers)
+make check-minimum-python-version # sitecustomize.py version gate matches the bundled distributions' Requires-Python
 make pyproto-unit-tests        # Vendored pyproto exporter test suites (throwaway venvs, no containers)
 make integration-test-metadata # Fast metadata tests (no containers)
 make integration-tests         # Full E2E tests (requires Podman/Docker)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,7 @@ packaging/
 testutil/                    Shared Go test helpers
   otelsink/                  In-process OTLP sink + typed assertion API for E2E tests
 docs/design/                 Architecture and design documents
+.github/scripts/             Shell scripts invoked by Makefile targets and CI workflows
 ```
 
 ## How package builds work

--- a/Makefile
+++ b/Makefile
@@ -471,6 +471,31 @@ pyproto-unit-tests:
 			$(PYPROTO_VENDOR_DIR)/$$suite; \
 	done
 
+# Check that the sitecustomize.py version gate stays in sync with the strictest
+# Requires-Python across the bundled distributions. The PyPI pins are installed
+# into a throwaway venv (excluding the vendored source lines) purely so the tool
+# can read their Requires-Python metadata; the vendored floor is read straight
+# from each vendor pyproject.toml via --vendor-dir, so the vendored source does
+# not need to be built for the check.
+#
+# The venv is built with the minimum supported interpreter (MINIMUM_PYTHON, the
+# current 3.x floor) on purpose: pip must resolve transitive dependencies the
+# way it would on that floor, so a newer release of a transitive dependency that
+# raised its own Requires-Python does not inflate the derived floor above what
+# actually runs on the minimum interpreter. tomli is the tomllib backport the
+# tool falls back to under Python 3.10 (tomllib is standard library from 3.11).
+MINIMUM_PYTHON ?= python3.10
+.PHONY: check-minimum-python-version
+check-minimum-python-version:
+	$(MINIMUM_PYTHON) -m venv build/minimum-python-version-venv
+	build/minimum-python-version-venv/bin/pip install --quiet packaging tomli
+	grep -v '^\./vendor/' packaging/common/python/requirements.txt | \
+		build/minimum-python-version-venv/bin/pip install --quiet -r /dev/stdin
+	build/minimum-python-version-venv/bin/python \
+		packaging/common/python/sync_minimum_python_version.py --check \
+		--vendor-dir packaging/common/python/vendor \
+		--sitecustomize packaging/common/python/sitecustomize.py
+
 # ============================================================================
 # Lint
 # ============================================================================

--- a/Makefile
+++ b/Makefile
@@ -400,13 +400,15 @@ integration-test-rpm-vendor: local-rpm-repo local-rpm-vendor-repo
 go-unit-tests:
 	go test -v ./cmd/...
 
-# Unit tests for sitecustomize.py. They need the `packaging` module (a runtime
-# dependency of sitecustomize.py itself); a throwaway virtualenv keeps the
-# host Python untouched.
+# Unit tests for sitecustomize.py and sync_minimum_python_version.py. They need
+# the `packaging` module (a runtime dependency of sitecustomize.py itself) and,
+# under Python 3.10, the `tomli` backport that sync_minimum_python_version.py
+# falls back to where the stdlib tomllib is absent; a throwaway virtualenv keeps
+# the host Python untouched.
 .PHONY: python-unit-tests
 python-unit-tests:
 	python3 -m venv build/python-unit-tests-venv
-	build/python-unit-tests-venv/bin/pip install --quiet packaging
+	build/python-unit-tests-venv/bin/pip install --quiet packaging tomli
 	build/python-unit-tests-venv/bin/python -m unittest discover \
 		--start-directory packaging/common/python --pattern 'test_*.py' --verbose
 
@@ -472,27 +474,39 @@ pyproto-unit-tests:
 	done
 
 # Check that the sitecustomize.py version gate stays in sync with the strictest
-# Requires-Python across the bundled distributions. The PyPI pins are installed
-# into a throwaway venv (excluding the vendored source lines) purely so the tool
-# can read their Requires-Python metadata; the vendored floor is read straight
-# from each vendor pyproject.toml via --vendor-dir, so the vendored source does
-# not need to be built for the check.
+# Requires-Python across the distributions that actually ship. The PyPI pins
+# (excluding the vendored source lines) are installed with pip install --target
+# into a throwaway payload directory, the same way packaging/builder/download.go
+# assembles the payload for the DEB and the RPM, and the tool enumerates only
+# that directory. A virtualenv would additionally contain pip and setuptools
+# from "python -m venv" plus the tool's own tomli, none of which ship; since the
+# floor is a maximum, a non-shipped distribution can only raise it, which would
+# mask a floor that should drop while the check still reported "in sync".
 #
-# The venv is built with the minimum supported interpreter (MINIMUM_PYTHON, the
-# current 3.x floor) on purpose: pip must resolve transitive dependencies the
-# way it would on that floor, so a newer release of a transitive dependency that
-# raised its own Requires-Python does not inflate the derived floor above what
-# actually runs on the minimum interpreter. tomli is the tomllib backport the
-# tool falls back to under Python 3.10 (tomllib is standard library from 3.11).
+# The vendored floor is read straight from each vendor pyproject.toml via
+# --vendor-dir, so the vendored source does not need to be built for the check.
+#
+# The venv that runs the tool is built with the minimum supported interpreter
+# (MINIMUM_PYTHON, the current 3.x floor) on purpose: its pip must resolve the
+# payload's transitive dependencies the way it would on that floor, so a newer
+# release of a transitive dependency that raised its own Requires-Python does
+# not inflate the derived floor above what actually runs on the minimum
+# interpreter. tomli is the tomllib backport the tool falls back to under
+# Python 3.10 (tomllib is standard library from 3.11).
 MINIMUM_PYTHON ?= python3.10
+MINIMUM_PYTHON_VENV = build/minimum-python-version-venv
+MINIMUM_PYTHON_PAYLOAD = build/minimum-python-version-payload
 .PHONY: check-minimum-python-version
 check-minimum-python-version:
-	$(MINIMUM_PYTHON) -m venv build/minimum-python-version-venv
-	build/minimum-python-version-venv/bin/pip install --quiet packaging tomli
+	$(MINIMUM_PYTHON) -m venv $(MINIMUM_PYTHON_VENV)
+	$(MINIMUM_PYTHON_VENV)/bin/pip install --quiet packaging tomli
+	rm -rf $(MINIMUM_PYTHON_PAYLOAD)
 	grep -v '^\./vendor/' packaging/common/python/requirements.txt | \
-		build/minimum-python-version-venv/bin/pip install --quiet -r /dev/stdin
-	build/minimum-python-version-venv/bin/python \
+		$(MINIMUM_PYTHON_VENV)/bin/pip install --quiet \
+			--target $(MINIMUM_PYTHON_PAYLOAD) -r /dev/stdin
+	$(MINIMUM_PYTHON_VENV)/bin/python \
 		packaging/common/python/sync_minimum_python_version.py --check \
+		--payload-dir $(MINIMUM_PYTHON_PAYLOAD) \
 		--vendor-dir packaging/common/python/vendor \
 		--sitecustomize packaging/common/python/sitecustomize.py
 

--- a/Makefile
+++ b/Makefile
@@ -474,41 +474,14 @@ pyproto-unit-tests:
 	done
 
 # Check that the sitecustomize.py version gate stays in sync with the strictest
-# Requires-Python across the distributions that actually ship. The PyPI pins
-# (excluding the vendored source lines) are installed with pip install --target
-# into a throwaway payload directory, the same way packaging/builder/download.go
-# assembles the payload for the DEB and the RPM, and the tool enumerates only
-# that directory. A virtualenv would additionally contain pip and setuptools
-# from "python -m venv" plus the tool's own tomli, none of which ship; since the
-# floor is a maximum, a non-shipped distribution can only raise it, which would
-# mask a floor that should drop while the check still reported "in sync".
-#
-# The vendored floor is read straight from each vendor pyproject.toml via
-# --vendor-dir, so the vendored source does not need to be built for the check.
-#
-# The venv that runs the tool is built with the minimum supported interpreter
-# (MINIMUM_PYTHON, the current 3.x floor) on purpose: its pip must resolve the
-# payload's transitive dependencies the way it would on that floor, so a newer
-# release of a transitive dependency that raised its own Requires-Python does
-# not inflate the derived floor above what actually runs on the minimum
-# interpreter. tomli is the tomllib backport the tool falls back to under
-# Python 3.10 (tomllib is standard library from 3.11).
-MINIMUM_PYTHON ?= python3.10
-MINIMUM_PYTHON_VENV = build/minimum-python-version-venv
-MINIMUM_PYTHON_PAYLOAD = build/minimum-python-version-payload
+# Requires-Python across the distributions that actually ship. The script
+# documents how the floor is derived, why only the shipped payload contributes
+# to it, and why the minimum supported interpreter derives it; it also takes
+# --write to rewrite the gate, and reads MINIMUM_PYTHON and BUILD_DIR from the
+# environment.
 .PHONY: check-minimum-python-version
 check-minimum-python-version:
-	$(MINIMUM_PYTHON) -m venv $(MINIMUM_PYTHON_VENV)
-	$(MINIMUM_PYTHON_VENV)/bin/pip install --quiet packaging tomli
-	rm -rf $(MINIMUM_PYTHON_PAYLOAD)
-	grep -v '^\./vendor/' packaging/common/python/requirements.txt | \
-		$(MINIMUM_PYTHON_VENV)/bin/pip install --quiet \
-			--target $(MINIMUM_PYTHON_PAYLOAD) -r /dev/stdin
-	$(MINIMUM_PYTHON_VENV)/bin/python \
-		packaging/common/python/sync_minimum_python_version.py --check \
-		--payload-dir $(MINIMUM_PYTHON_PAYLOAD) \
-		--vendor-dir packaging/common/python/vendor \
-		--sitecustomize packaging/common/python/sitecustomize.py
+	.github/scripts/check-minimum-python-version.sh --check
 
 # ============================================================================
 # Lint

--- a/packaging/common/python/README.md
+++ b/packaging/common/python/README.md
@@ -87,6 +87,7 @@ export OTEL_CONFIG_FILE=/etc/opentelemetry/python/otel-config.yaml
 `sitecustomize.py` performs the following checks at startup before activating instrumentation:
 
 1. **Python version**: Requires Python ≥ 3.10. Older versions are skipped gracefully.
+   This floor is derived from the strictest Requires-Python across the bundled distributions, and it is kept in sync automatically by `sync_minimum_python_version.py`.
 2. **OTLP protocol / configuration file**: Without `OTEL_CONFIG_FILE`, accepts
    `OTEL_EXPORTER_OTLP_PROTOCOL` of `grpc` (the default when unset) or `http/protobuf`;
    `http/json` self-deactivates. With `OTEL_CONFIG_FILE` set,

--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -364,9 +364,13 @@ def import_distro():
     _log_debug("checking Python version")
     current_site = dirname(__file__)
 
-    # Require Python >= 3.10 (opentelemetry-exporter-otlp-pyproto-http minimum).
+    # Require Python >= 3.10. This floor is the strictest Requires-Python lower
+    # bound across the bundled distributions. Keep it in sync with them by
+    # running sync_minimum_python_version.py (CI enforces this via the
+    # check-minimum-python-version make target); do not edit the constant by hand.
     # We cannot use named attributes (e.g. sys.version_info.major) as those were introduced in 3.1.
-    if version_info[0] != 3 or version_info[1] < 10:
+    _MINIMUM_PYTHON_MINOR = 10  # sync-minimum-python-version: 3.x minor floor
+    if version_info[0] != 3 or version_info[1] < _MINIMUM_PYTHON_MINOR:
         _self_deactivate(current_site)
         _log_cannot_auto_instrument_warning("unsupported Python version: {}".format(version))
         return

--- a/packaging/common/python/sync_minimum_python_version.py
+++ b/packaging/common/python/sync_minimum_python_version.py
@@ -4,10 +4,21 @@
 """Derive and enforce the sitecustomize.py minimum Python version.
 
 The minimum supported Python of the bundled agent is the strictest
-Requires-Python lower bound across every distribution installed in the running
-interpreter (the PyPI pins from requirements.txt) and every vendored package's
-pyproject.toml. This script derives that floor and either checks it against the
-sitecustomize.py version gate (--check) or rewrites the gate to match (--write).
+Requires-Python lower bound across every distribution that ships in the package
+and every vendored package's pyproject.toml. This script derives that floor and
+either checks it against the sitecustomize.py version gate (--check) or rewrites
+the gate to match (--write).
+
+The shipped distributions are enumerated from the payload directory named by
+--payload-dir: the directory that a "pip install --target" of requirements.txt
+produces, which is what packaging/builder/download.go writes into the DEB and
+the RPM. Scoping the enumeration to that directory keeps distributions that
+never ship out of the derivation: pip and setuptools, which "python -m venv"
+creates in any surrounding virtualenv, and tomli, which only this tool imports.
+Because the floor is a maximum over per-distribution lower bounds, a
+distribution that does not ship can only raise it and never lower it, so
+including one would mask a floor that should drop while --check still reported
+the gate as in sync.
 
 The gate is a plain integer comparison in sitecustomize.py so that the file
 still parses and runs on ancient interpreters. The comparison reads a named
@@ -119,6 +130,12 @@ def main():
         default=join(script_directory, "sitecustomize.py"),
         help="path to sitecustomize.py (default: next to this script)")
     argument_parser.add_argument(
+        "--payload-dir",
+        required=True,
+        help="directory holding the distributions that ship in the package, "
+             "as produced by pip install --target; only the distributions "
+             "found there contribute to the derived floor")
+    argument_parser.add_argument(
         "--vendor-dir",
         default=join(script_directory, "vendor"),
         help="directory tree searched for vendored pyproject.toml files "
@@ -134,13 +151,25 @@ def main():
         help="rewrite the gate constant to match the derived floor")
     arguments = argument_parser.parse_args()
 
-    # Collect Requires-Python from every installed distribution, then from
-    # every vendored pyproject.toml. The importlib.metadata enumeration and the
-    # pyproject reads are inlined here (each is used only in this one place);
-    # the derivation logic they feed is a reusable, separately tested function.
+    # Collect Requires-Python from every shipped distribution, then from every
+    # vendored pyproject.toml. The enumeration is scoped to the payload
+    # directory with path=; called with no arguments, distributions() would walk
+    # the running interpreter's sys.path and pick up pip, setuptools and tomli,
+    # which the DEB and the RPM never ship. The importlib.metadata enumeration
+    # and the pyproject reads are inlined here (each is used only in this one
+    # place); the derivation logic they feed is a reusable, separately tested
+    # function.
+    shipped_distributions = list(distributions(path=[arguments.payload_dir]))
+    if not shipped_distributions:
+        print(
+            "no distributions found in payload directory {}: it is missing or "
+            "empty, and must be populated with pip install --target before "
+            "running this check".format(arguments.payload_dir),
+            file=stderr)
+        return 1
     requires_python_strings = [
         distribution.metadata["Requires-Python"]
-        for distribution in distributions()]
+        for distribution in shipped_distributions]
     for pyproject_path in Path(arguments.vendor_dir).rglob("pyproject.toml"):
         with open(pyproject_path, "rb") as pyproject_file:
             pyproject_data = load(pyproject_file)

--- a/packaging/common/python/sync_minimum_python_version.py
+++ b/packaging/common/python/sync_minimum_python_version.py
@@ -1,0 +1,199 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Derive and enforce the sitecustomize.py minimum Python version.
+
+The minimum supported Python of the bundled agent is the strictest
+Requires-Python lower bound across every distribution installed in the running
+interpreter (the PyPI pins from requirements.txt) and every vendored package's
+pyproject.toml. This script derives that floor and either checks it against the
+sitecustomize.py version gate (--check) or rewrites the gate to match (--write).
+
+The gate is a plain integer comparison in sitecustomize.py so that the file
+still parses and runs on ancient interpreters. The comparison reads a named
+constant marked with an anchor comment:
+
+    _MINIMUM_PYTHON_MINOR = 10  # sync-minimum-python-version: 3.x minor floor
+
+This script only knows how to keep the minor of a 3.x floor in sync. If the
+derived major is not 3, it exits with an error asking for a gate refactor.
+"""
+
+from argparse import ArgumentParser
+from importlib.metadata import distributions
+from os.path import dirname, join
+from pathlib import Path
+from re import compile as re_compile
+from sys import stderr
+
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+# tomllib is standard library since Python 3.11. This tool must also run under
+# the current 3.10 floor (so pip resolves transitive dependencies exactly as it
+# would on the minimum interpreter), where tomllib is absent and the tomli
+# backport is installed alongside packaging instead.
+try:
+    from tomllib import load
+except ModuleNotFoundError:
+    from tomli import load
+
+# The lowest major.minor pairs we scan when probing a specifier for the lowest
+# version it admits. Python 3 minors are the realistic range for this project;
+# major 4 is included so that a future 4.x-only floor is detected and reported
+# as needing a gate refactor rather than silently mis-derived.
+_CANDIDATE_VERSIONS = [(3, minor) for minor in range(0, 31)] + [
+    (4, minor) for minor in range(0, 31)
+]
+
+_GATE_CONSTANT_PATTERN = re_compile(
+    r"_MINIMUM_PYTHON_MINOR = (\d+)  # sync-minimum-python-version")
+
+_HUMAN_READABLE_COMMENT_PATTERN = re_compile(r"# Require Python >= 3\.\d+\b")
+
+
+def lowest_supported_major_minor_across_requires_python(
+        requires_python_strings):
+    """Return the strictest (major, minor) lower bound over the given specs.
+
+    Each item is a Requires-Python string (for example ">=3.10" or
+    "~=3.11,!=3.12.*"). For each specifier we find the lowest candidate
+    major.minor it admits, then return the maximum of those per-specifier
+    minimums: the floor every bundled distribution can agree on. Strings that
+    are empty or None are ignored (a distribution without Requires-Python
+    imposes no floor).
+    """
+    per_specifier_minimums = []
+    for requires_python in requires_python_strings:
+        if not requires_python:
+            continue
+        specifier_set = SpecifierSet(requires_python)
+        lowest_admitted = None
+        for major, minor in _CANDIDATE_VERSIONS:
+            if specifier_set.contains(Version("{}.{}".format(major, minor))):
+                lowest_admitted = (major, minor)
+                break
+        if lowest_admitted is not None:
+            per_specifier_minimums.append(lowest_admitted)
+    if not per_specifier_minimums:
+        return None
+    return max(per_specifier_minimums)
+
+
+def read_gate_minor_from_sitecustomize(sitecustomize_text):
+    """Return the current _MINIMUM_PYTHON_MINOR integer from the gate marker."""
+    match = _GATE_CONSTANT_PATTERN.search(sitecustomize_text)
+    if match is None:
+        raise ValueError(
+            "no sync-minimum-python-version marker found in sitecustomize.py")
+    return int(match.group(1))
+
+
+def rewrite_gate_minor_in_sitecustomize(sitecustomize_text, new_minor):
+    """Return sitecustomize text with the gate minor set to new_minor.
+
+    Rewrites both the marked constant line and the human-readable
+    "# Require Python >= 3.N" comment above it. Asserts that exactly one
+    marker line is present before substituting.
+    """
+    marker_match_count = len(
+        _GATE_CONSTANT_PATTERN.findall(sitecustomize_text))
+    if marker_match_count != 1:
+        raise ValueError(
+            "expected exactly 1 sync-minimum-python-version marker, "
+            "found {}".format(marker_match_count))
+    rewritten = _GATE_CONSTANT_PATTERN.sub(
+        "_MINIMUM_PYTHON_MINOR = {}  # sync-minimum-python-version".format(
+            new_minor),
+        sitecustomize_text)
+    rewritten = _HUMAN_READABLE_COMMENT_PATTERN.sub(
+        "# Require Python >= 3.{}".format(new_minor), rewritten)
+    return rewritten
+
+
+def main():
+    argument_parser = ArgumentParser(description=__doc__)
+    script_directory = dirname(__file__)
+    argument_parser.add_argument(
+        "--sitecustomize",
+        default=join(script_directory, "sitecustomize.py"),
+        help="path to sitecustomize.py (default: next to this script)")
+    argument_parser.add_argument(
+        "--vendor-dir",
+        default=join(script_directory, "vendor"),
+        help="directory tree searched for vendored pyproject.toml files "
+             "(default: the vendor dir next to this script)")
+    mode_group = argument_parser.add_mutually_exclusive_group(required=True)
+    mode_group.add_argument(
+        "--check",
+        action="store_true",
+        help="verify the gate matches the derived floor; exit 1 if it differs")
+    mode_group.add_argument(
+        "--write",
+        action="store_true",
+        help="rewrite the gate constant to match the derived floor")
+    arguments = argument_parser.parse_args()
+
+    # Collect Requires-Python from every installed distribution, then from
+    # every vendored pyproject.toml. The importlib.metadata enumeration and the
+    # pyproject reads are inlined here (each is used only in this one place);
+    # the derivation logic they feed is a reusable, separately tested function.
+    requires_python_strings = [
+        distribution.metadata["Requires-Python"]
+        for distribution in distributions()]
+    for pyproject_path in Path(arguments.vendor_dir).rglob("pyproject.toml"):
+        with open(pyproject_path, "rb") as pyproject_file:
+            pyproject_data = load(pyproject_file)
+        requires_python_strings.append(
+            pyproject_data.get("project", {}).get("requires-python"))
+
+    derived_floor = lowest_supported_major_minor_across_requires_python(
+        requires_python_strings)
+    if derived_floor is None:
+        print(
+            "could not derive a minimum Python version: no distribution or "
+            "vendored pyproject declared Requires-Python",
+            file=stderr)
+        return 1
+    derived_major, derived_minor = derived_floor
+    if derived_major != 3:
+        print(
+            "derived minimum Python major is {}, not 3; the sitecustomize.py "
+            "gate refactor only supports 3.x floors and must be updated for "
+            "major-version bumps".format(derived_major),
+            file=stderr)
+        return 1
+
+    with open(arguments.sitecustomize, encoding="utf-8") as sitecustomize_file:
+        sitecustomize_text = sitecustomize_file.read()
+    current_minor = read_gate_minor_from_sitecustomize(sitecustomize_text)
+
+    if arguments.check:
+        print("derived minimum Python: 3.{}".format(derived_minor))
+        print("sitecustomize gate: 3.{}".format(current_minor))
+        if derived_minor != current_minor:
+            print(
+                "gate is out of sync with the bundled distributions; run "
+                "sync_minimum_python_version.py --write to update it",
+                file=stderr)
+            return 1
+        print("gate is in sync")
+        return 0
+
+    if derived_minor == current_minor:
+        print("gate already at 3.{}; nothing to rewrite".format(current_minor))
+        return 0
+    rewritten_text = rewrite_gate_minor_in_sitecustomize(
+        sitecustomize_text, derived_minor)
+    with open(
+            arguments.sitecustomize, "w",
+            encoding="utf-8") as sitecustomize_file:
+        sitecustomize_file.write(rewritten_text)
+    print(
+        "rewrote sitecustomize gate from 3.{} to 3.{}".format(
+            current_minor, derived_minor))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packaging/common/python/test_sync_minimum_python_version.py
+++ b/packaging/common/python/test_sync_minimum_python_version.py
@@ -1,0 +1,196 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for sync_minimum_python_version.py."""
+
+from pathlib import Path
+from subprocess import run
+from sys import executable
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from sync_minimum_python_version import (
+    lowest_supported_major_minor_across_requires_python,
+    read_gate_minor_from_sitecustomize,
+    rewrite_gate_minor_in_sitecustomize,
+)
+
+_TOOL_PATH = str(Path(__file__).with_name("sync_minimum_python_version.py"))
+
+_MINIMAL_SITECUSTOMIZE = (
+    "# Require Python >= 3.10. This floor is the strictest.\n"
+    "_MINIMUM_PYTHON_MINOR = 10  # sync-minimum-python-version: 3.x minor floor\n"
+    "if version_info[0] != 3 or version_info[1] < _MINIMUM_PYTHON_MINOR:\n"
+    "    pass\n"
+)
+
+
+class TestDeriveFloorFromRequiresPython(TestCase):
+
+    def test_strictest_lower_bound_wins(self):
+        self.assertEqual(
+            lowest_supported_major_minor_across_requires_python(
+                [">=3.9", ">=3.10", ">=3.8,<4"]),
+            (3, 10))
+
+    def test_compatible_release_specifier_resolves_to_its_minor(self):
+        self.assertEqual(
+            lowest_supported_major_minor_across_requires_python(["~=3.11"]),
+            (3, 11))
+
+    def test_empty_and_none_specifiers_are_ignored(self):
+        self.assertEqual(
+            lowest_supported_major_minor_across_requires_python(
+                [None, "", ">=3.12"]),
+            (3, 12))
+
+    def test_no_specifiers_yields_none(self):
+        self.assertIsNone(
+            lowest_supported_major_minor_across_requires_python([None, ""]))
+
+
+class TestVendorPyprojectParsing(TestCase):
+
+    def test_check_reads_requires_python_from_vendor_pyproject(self):
+        # A temp vendor dir whose only pyproject floor (3.12) exceeds the gate
+        # (3.10) must drive --check to report an out-of-sync gate. This proves
+        # the tool reads [project].requires-python from pyproject.toml files
+        # found under --vendor-dir.
+        with TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            vendor_directory = temporary_path / "vendor" / "some-package"
+            vendor_directory.mkdir(parents=True)
+            (vendor_directory / "pyproject.toml").write_text(
+                "[project]\n"
+                'name = "some-package"\n'
+                'requires-python = ">=3.12"\n',
+                encoding="utf-8")
+            sitecustomize_path = temporary_path / "sitecustomize.py"
+            sitecustomize_path.write_text(
+                _MINIMAL_SITECUSTOMIZE, encoding="utf-8")
+
+            completed = run(
+                [
+                    executable, _TOOL_PATH, "--check",
+                    "--vendor-dir", str(temporary_path / "vendor"),
+                    "--sitecustomize", str(sitecustomize_path),
+                ],
+                capture_output=True, text=True)
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("3.12", completed.stdout)
+
+
+class TestGateConstantReadAndRewrite(TestCase):
+
+    def test_read_gate_minor_from_marker_line(self):
+        self.assertEqual(
+            read_gate_minor_from_sitecustomize(_MINIMAL_SITECUSTOMIZE), 10)
+
+    def test_read_gate_minor_without_marker_raises(self):
+        with self.assertRaises(ValueError):
+            read_gate_minor_from_sitecustomize("no marker here\n")
+
+    def test_rewrite_updates_constant_and_human_readable_comment(self):
+        rewritten = rewrite_gate_minor_in_sitecustomize(
+            _MINIMAL_SITECUSTOMIZE, 12)
+        self.assertIn(
+            "_MINIMUM_PYTHON_MINOR = 12  # sync-minimum-python-version",
+            rewritten)
+        self.assertIn("# Require Python >= 3.12", rewritten)
+        self.assertNotIn("3.10", rewritten)
+        self.assertEqual(read_gate_minor_from_sitecustomize(rewritten), 12)
+
+    def test_rewrite_requires_exactly_one_marker(self):
+        with self.assertRaises(ValueError):
+            rewrite_gate_minor_in_sitecustomize("no marker here\n", 12)
+
+
+class TestCheckAndWriteEndToEnd(TestCase):
+
+    def test_check_exits_zero_when_gate_matches_and_nonzero_when_not(self):
+        # The running interpreter's installed distributions plus an empty
+        # vendor dir yield some 3.x floor. Whatever it is, a gate set to that
+        # exact minor must pass --check, and a gate set one minor higher must
+        # fail. We discover the floor from the passing run, then perturb it.
+        with TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            empty_vendor = temporary_path / "vendor"
+            empty_vendor.mkdir()
+
+            probe_sitecustomize = temporary_path / "probe_sitecustomize.py"
+            probe_sitecustomize.write_text(
+                _MINIMAL_SITECUSTOMIZE, encoding="utf-8")
+            probe = run(
+                [
+                    executable, _TOOL_PATH, "--check",
+                    "--vendor-dir", str(empty_vendor),
+                    "--sitecustomize", str(probe_sitecustomize),
+                ],
+                capture_output=True, text=True)
+            derived_line = next(
+                line for line in probe.stdout.splitlines()
+                if line.startswith("derived minimum Python: 3."))
+            derived_minor = int(derived_line.rsplit(".", 1)[1])
+
+            matching_sitecustomize = temporary_path / "matching.py"
+            matching_sitecustomize.write_text(
+                _MINIMAL_SITECUSTOMIZE.replace(
+                    "= 10  #", "= {}  #".format(derived_minor)).replace(
+                    ">= 3.10", ">= 3.{}".format(derived_minor)),
+                encoding="utf-8")
+            matching = run(
+                [
+                    executable, _TOOL_PATH, "--check",
+                    "--vendor-dir", str(empty_vendor),
+                    "--sitecustomize", str(matching_sitecustomize),
+                ],
+                capture_output=True, text=True)
+            self.assertEqual(matching.returncode, 0, matching.stderr)
+
+            mismatching_sitecustomize = temporary_path / "mismatching.py"
+            mismatching_sitecustomize.write_text(
+                _MINIMAL_SITECUSTOMIZE.replace(
+                    "= 10  #", "= {}  #".format(derived_minor + 1)).replace(
+                    ">= 3.10", ">= 3.{}".format(derived_minor + 1)),
+                encoding="utf-8")
+            mismatching = run(
+                [
+                    executable, _TOOL_PATH, "--check",
+                    "--vendor-dir", str(empty_vendor),
+                    "--sitecustomize", str(mismatching_sitecustomize),
+                ],
+                capture_output=True, text=True)
+            self.assertNotEqual(mismatching.returncode, 0)
+
+    def test_write_rewrites_marker_and_comment_to_derived_floor(self):
+        # A temp vendor pyproject with a 3.13 floor forces the derived floor to
+        # at least 3.13. --write must rewrite the temp sitecustomize to that
+        # minor in both the constant and the human-readable comment.
+        with TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            vendor_directory = temporary_path / "vendor" / "high-floor"
+            vendor_directory.mkdir(parents=True)
+            (vendor_directory / "pyproject.toml").write_text(
+                "[project]\n"
+                'name = "high-floor"\n'
+                'requires-python = ">=3.13"\n',
+                encoding="utf-8")
+            sitecustomize_path = temporary_path / "sitecustomize.py"
+            sitecustomize_path.write_text(
+                _MINIMAL_SITECUSTOMIZE, encoding="utf-8")
+
+            completed = run(
+                [
+                    executable, _TOOL_PATH, "--write",
+                    "--vendor-dir", str(temporary_path / "vendor"),
+                    "--sitecustomize", str(sitecustomize_path),
+                ],
+                capture_output=True, text=True)
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+
+            rewritten = sitecustomize_path.read_text(encoding="utf-8")
+            self.assertIn(
+                "_MINIMUM_PYTHON_MINOR = 13  # sync-minimum-python-version",
+                rewritten)
+            self.assertIn("# Require Python >= 3.13", rewritten)

--- a/packaging/common/python/test_sync_minimum_python_version.py
+++ b/packaging/common/python/test_sync_minimum_python_version.py
@@ -25,6 +25,47 @@ _MINIMAL_SITECUSTOMIZE = (
 )
 
 
+def write_dist_info_with_requires_python(
+        payload_directory, name, version, requires_python):
+    """Create a <name>-<version>.dist-info/METADATA under payload_directory.
+
+    This is the minimum importlib.metadata needs to enumerate a distribution
+    and report its Requires-Python, so a payload can be assembled offline
+    without installing anything.
+    """
+    dist_info_directory = payload_directory / "{}-{}.dist-info".format(
+        name, version)
+    dist_info_directory.mkdir(parents=True)
+    (dist_info_directory / "METADATA").write_text(
+        "Metadata-Version: 2.1\n"
+        "Name: {}\n"
+        "Version: {}\n"
+        "Requires-Python: {}\n".format(name, version, requires_python),
+        encoding="utf-8")
+
+
+def write_sitecustomize_with_gate_minor(sitecustomize_path, gate_minor):
+    """Write a minimal sitecustomize.py whose gate constant holds gate_minor."""
+    sitecustomize_path.write_text(
+        _MINIMAL_SITECUSTOMIZE.replace(
+            "= 10  #", "= {}  #".format(gate_minor)).replace(
+            ">= 3.10", ">= 3.{}".format(gate_minor)),
+        encoding="utf-8")
+
+
+def run_sync_minimum_python_version(
+        mode, payload_directory, vendor_directory, sitecustomize_path):
+    """Run the tool in --check or --write mode and return the completed run."""
+    return run(
+        [
+            executable, _TOOL_PATH, mode,
+            "--payload-dir", str(payload_directory),
+            "--vendor-dir", str(vendor_directory),
+            "--sitecustomize", str(sitecustomize_path),
+        ],
+        capture_output=True, text=True)
+
+
 class TestDeriveFloorFromRequiresPython(TestCase):
 
     def test_strictest_lower_bound_wins(self):
@@ -49,15 +90,106 @@ class TestDeriveFloorFromRequiresPython(TestCase):
             lowest_supported_major_minor_across_requires_python([None, ""]))
 
 
+class TestPayloadScopedEnumeration(TestCase):
+
+    def test_floor_comes_only_from_the_payload_directory(self):
+        # The payload declares a single distribution at >=3.7, so the floor is
+        # 3.7 and a gate of 7 is in sync. The interpreter running this test has
+        # packaging installed (>=3.9), plus pip and setuptools from the
+        # throwaway venv the python-unit-tests target builds. An enumeration
+        # that walked sys.path instead of --payload-dir would derive at least
+        # 3.9 from those and report the gate as out of sync, so passing here is
+        # what proves the enumeration is scoped to the payload.
+        with TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            payload_directory = temporary_path / "payload"
+            write_dist_info_with_requires_python(
+                payload_directory, "shipped_thing", "1.0", ">=3.7")
+            vendor_directory = temporary_path / "vendor"
+            vendor_directory.mkdir()
+            sitecustomize_path = temporary_path / "sitecustomize.py"
+            write_sitecustomize_with_gate_minor(sitecustomize_path, 7)
+
+            completed = run_sync_minimum_python_version(
+                "--check", payload_directory, vendor_directory,
+                sitecustomize_path)
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("derived minimum Python: 3.7", completed.stdout)
+
+    def test_strictest_payload_distribution_decides_the_floor(self):
+        with TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            payload_directory = temporary_path / "payload"
+            write_dist_info_with_requires_python(
+                payload_directory, "lenient_thing", "1.0", ">=3.9")
+            write_dist_info_with_requires_python(
+                payload_directory, "strict_thing", "2.0", ">=3.11")
+            vendor_directory = temporary_path / "vendor"
+            vendor_directory.mkdir()
+            sitecustomize_path = temporary_path / "sitecustomize.py"
+            write_sitecustomize_with_gate_minor(sitecustomize_path, 11)
+
+            completed = run_sync_minimum_python_version(
+                "--check", payload_directory, vendor_directory,
+                sitecustomize_path)
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("derived minimum Python: 3.11", completed.stdout)
+
+    def test_missing_payload_directory_fails(self):
+        # A mistyped or unbuilt payload path must be an error rather than a
+        # derivation from the vendored pyproject files alone, which would
+        # silently report a floor lower than the one the package ships.
+        with TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            vendor_directory = temporary_path / "vendor" / "some-package"
+            vendor_directory.mkdir(parents=True)
+            (vendor_directory / "pyproject.toml").write_text(
+                "[project]\n"
+                'name = "some-package"\n'
+                'requires-python = ">=3.10"\n',
+                encoding="utf-8")
+            sitecustomize_path = temporary_path / "sitecustomize.py"
+            write_sitecustomize_with_gate_minor(sitecustomize_path, 10)
+
+            completed = run_sync_minimum_python_version(
+                "--check", temporary_path / "no-such-payload",
+                temporary_path / "vendor", sitecustomize_path)
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("no distributions found", completed.stderr)
+
+    def test_empty_payload_directory_fails(self):
+        with TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            payload_directory = temporary_path / "payload"
+            payload_directory.mkdir()
+            vendor_directory = temporary_path / "vendor"
+            vendor_directory.mkdir()
+            sitecustomize_path = temporary_path / "sitecustomize.py"
+            write_sitecustomize_with_gate_minor(sitecustomize_path, 10)
+
+            completed = run_sync_minimum_python_version(
+                "--check", payload_directory, vendor_directory,
+                sitecustomize_path)
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("no distributions found", completed.stderr)
+
+
 class TestVendorPyprojectParsing(TestCase):
 
     def test_check_reads_requires_python_from_vendor_pyproject(self):
-        # A temp vendor dir whose only pyproject floor (3.12) exceeds the gate
-        # (3.10) must drive --check to report an out-of-sync gate. This proves
-        # the tool reads [project].requires-python from pyproject.toml files
-        # found under --vendor-dir.
+        # The payload floor (3.8) is below the only vendored pyproject floor
+        # (3.12), which must therefore drive --check to report the gate (3.10)
+        # as out of sync. This proves the tool reads [project].requires-python
+        # from pyproject.toml files found under --vendor-dir.
         with TemporaryDirectory() as temporary_directory:
             temporary_path = Path(temporary_directory)
+            payload_directory = temporary_path / "payload"
+            write_dist_info_with_requires_python(
+                payload_directory, "shipped_thing", "1.0", ">=3.8")
             vendor_directory = temporary_path / "vendor" / "some-package"
             vendor_directory.mkdir(parents=True)
             (vendor_directory / "pyproject.toml").write_text(
@@ -69,13 +201,9 @@ class TestVendorPyprojectParsing(TestCase):
             sitecustomize_path.write_text(
                 _MINIMAL_SITECUSTOMIZE, encoding="utf-8")
 
-            completed = run(
-                [
-                    executable, _TOOL_PATH, "--check",
-                    "--vendor-dir", str(temporary_path / "vendor"),
-                    "--sitecustomize", str(sitecustomize_path),
-                ],
-                capture_output=True, text=True)
+            completed = run_sync_minimum_python_version(
+                "--check", payload_directory, temporary_path / "vendor",
+                sitecustomize_path)
 
         self.assertNotEqual(completed.returncode, 0)
         self.assertIn("3.12", completed.stdout)
@@ -109,66 +237,42 @@ class TestGateConstantReadAndRewrite(TestCase):
 class TestCheckAndWriteEndToEnd(TestCase):
 
     def test_check_exits_zero_when_gate_matches_and_nonzero_when_not(self):
-        # The running interpreter's installed distributions plus an empty
-        # vendor dir yield some 3.x floor. Whatever it is, a gate set to that
-        # exact minor must pass --check, and a gate set one minor higher must
-        # fail. We discover the floor from the passing run, then perturb it.
+        # A payload whose strictest distribution declares >=3.11 fixes the
+        # derived floor at 3.11, so a gate of 11 must pass and a gate of 12
+        # must fail.
         with TemporaryDirectory() as temporary_directory:
             temporary_path = Path(temporary_directory)
-            empty_vendor = temporary_path / "vendor"
-            empty_vendor.mkdir()
-
-            probe_sitecustomize = temporary_path / "probe_sitecustomize.py"
-            probe_sitecustomize.write_text(
-                _MINIMAL_SITECUSTOMIZE, encoding="utf-8")
-            probe = run(
-                [
-                    executable, _TOOL_PATH, "--check",
-                    "--vendor-dir", str(empty_vendor),
-                    "--sitecustomize", str(probe_sitecustomize),
-                ],
-                capture_output=True, text=True)
-            derived_line = next(
-                line for line in probe.stdout.splitlines()
-                if line.startswith("derived minimum Python: 3."))
-            derived_minor = int(derived_line.rsplit(".", 1)[1])
+            payload_directory = temporary_path / "payload"
+            write_dist_info_with_requires_python(
+                payload_directory, "shipped_thing", "1.0", ">=3.11")
+            vendor_directory = temporary_path / "vendor"
+            vendor_directory.mkdir()
 
             matching_sitecustomize = temporary_path / "matching.py"
-            matching_sitecustomize.write_text(
-                _MINIMAL_SITECUSTOMIZE.replace(
-                    "= 10  #", "= {}  #".format(derived_minor)).replace(
-                    ">= 3.10", ">= 3.{}".format(derived_minor)),
-                encoding="utf-8")
-            matching = run(
-                [
-                    executable, _TOOL_PATH, "--check",
-                    "--vendor-dir", str(empty_vendor),
-                    "--sitecustomize", str(matching_sitecustomize),
-                ],
-                capture_output=True, text=True)
+            write_sitecustomize_with_gate_minor(matching_sitecustomize, 11)
+            matching = run_sync_minimum_python_version(
+                "--check", payload_directory, vendor_directory,
+                matching_sitecustomize)
             self.assertEqual(matching.returncode, 0, matching.stderr)
 
             mismatching_sitecustomize = temporary_path / "mismatching.py"
-            mismatching_sitecustomize.write_text(
-                _MINIMAL_SITECUSTOMIZE.replace(
-                    "= 10  #", "= {}  #".format(derived_minor + 1)).replace(
-                    ">= 3.10", ">= 3.{}".format(derived_minor + 1)),
-                encoding="utf-8")
-            mismatching = run(
-                [
-                    executable, _TOOL_PATH, "--check",
-                    "--vendor-dir", str(empty_vendor),
-                    "--sitecustomize", str(mismatching_sitecustomize),
-                ],
-                capture_output=True, text=True)
-            self.assertNotEqual(mismatching.returncode, 0)
+            write_sitecustomize_with_gate_minor(mismatching_sitecustomize, 12)
+            mismatching = run_sync_minimum_python_version(
+                "--check", payload_directory, vendor_directory,
+                mismatching_sitecustomize)
+
+        self.assertNotEqual(mismatching.returncode, 0)
 
     def test_write_rewrites_marker_and_comment_to_derived_floor(self):
-        # A temp vendor pyproject with a 3.13 floor forces the derived floor to
-        # at least 3.13. --write must rewrite the temp sitecustomize to that
-        # minor in both the constant and the human-readable comment.
+        # A vendored pyproject with a 3.13 floor above the payload's 3.10 puts
+        # the derived floor at 3.13. --write must rewrite the temp
+        # sitecustomize to that minor in both the constant and the
+        # human-readable comment.
         with TemporaryDirectory() as temporary_directory:
             temporary_path = Path(temporary_directory)
+            payload_directory = temporary_path / "payload"
+            write_dist_info_with_requires_python(
+                payload_directory, "shipped_thing", "1.0", ">=3.10")
             vendor_directory = temporary_path / "vendor" / "high-floor"
             vendor_directory.mkdir(parents=True)
             (vendor_directory / "pyproject.toml").write_text(
@@ -180,13 +284,9 @@ class TestCheckAndWriteEndToEnd(TestCase):
             sitecustomize_path.write_text(
                 _MINIMAL_SITECUSTOMIZE, encoding="utf-8")
 
-            completed = run(
-                [
-                    executable, _TOOL_PATH, "--write",
-                    "--vendor-dir", str(temporary_path / "vendor"),
-                    "--sitecustomize", str(sitecustomize_path),
-                ],
-                capture_output=True, text=True)
+            completed = run_sync_minimum_python_version(
+                "--write", payload_directory, temporary_path / "vendor",
+                sitecustomize_path)
             self.assertEqual(completed.returncode, 0, completed.stderr)
 
             rewritten = sitecustomize_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## What

Derive the minimum supported Python of the bundled agent from the strictest `Requires-Python` across the bundled distributions, and keep the `sitecustomize.py` version gate in sync with it instead of relying on a hand-maintained magic number.

Closes #78.

## Why

The floor was hard-coded in `sitecustomize.py` (`version_info[1] < 10`) with nothing tying it to the distributions we actually ship. When a dependency bump raises the minimum supported Python, that gate silently drifts.

## How

- Refactor the gate into a named constant with an anchor comment, so it stays a plain integer comparison that still parses and runs on ancient interpreters, while giving the tooling an unambiguous target:

  ```python
  _MINIMUM_PYTHON_MINOR = 10  # sync-minimum-python-version: 3.x minor floor
  if version_info[0] != 3 or version_info[1] < _MINIMUM_PYTHON_MINOR:
  ```

- Add `packaging/common/python/sync_minimum_python_version.py`. It derives the floor as the strictest `Requires-Python` lower bound over every installed distribution plus every vendored `pyproject.toml`, then either verifies the gate (`--check`) or rewrites it (`--write`).
- Add `make check-minimum-python-version`, wired into the `unit-tests` CI job. It installs the PyPI pins into a throwaway venv purely to read their metadata, and reads the vendored floor straight from each vendor `pyproject.toml`.
- Add offline unit tests for the derivation, gate parsing, and rewrite logic (discovered by `make python-unit-tests`).

## Design note (feedback welcome)

The check venv is built with the minimum supported interpreter (3.10) on purpose, so pip resolves transitive dependencies the way they resolve on the floor. A newer `rpds-py` release requiring 3.11 otherwise inflated the derived floor under a modern host.

The effect: this is robust detection plus a convenience `--write` for the current floor, not fully automatic raising. When a pinned package actually raises its `Requires-Python` above the floor, `pip install` under 3.10 fails and CI goes red, and a maintainer bumps the gate and `MINIMUM_PYTHON` deliberately. That keeps dropping a supported Python version a conscious decision rather than a silent bot edit. Happy to switch to direct-pin-only derivation under a modern interpreter if maintainers prefer `--write` to auto-raise.

## Testing

- `make python-unit-tests` (new tests discovered and passing).
- `make check-minimum-python-version` derives 3.10, matches the gate, exits 0.
