### PR TITLE
Verify Python package checksums against PyPI's published digests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,6 +119,17 @@ jobs:
           path: ./build/packages
 
       - name: Run packaging integration tests for ${{ matrix.SYS_PACKAGE }}/${{ matrix.lang }}/${{ matrix.arch }}
+        env:
+          # local-apt-repo (a prerequisite of every integration-test-*
+          # target) rebuilds the packages locally via the .PHONY
+          # deb-packages/rpm-packages targets, re-running
+          # downloadInjector/downloadJavaAgent's GitHub asset-digest lookups
+          # even though a prebuilt package was already downloaded above.
+          # Without a token those lookups share the 60/hour unauthenticated
+          # GitHub API rate limit across every concurrent job in this
+          # matrix (and the rest of the runner IP pool), which is easy to
+          # exhaust; see the build-packages job for the same reasoning.
+          GITHUB_TOKEN: ${{ github.token }}
         run: make integration-test-${{ matrix.SYS_PACKAGE }}-${{ matrix.lang }} ARCH=${{ matrix.arch }}
 
   publish-release:

--- a/packaging/builder/download.go
+++ b/packaging/builder/download.go
@@ -83,6 +83,10 @@ func fetchGitHubAssetDigest(owner, repo, tag, assetName string) (string, error) 
 	return "", fmt.Errorf("release %s/%s@%s has no asset named %s", owner, repo, tag, assetName)
 }
 
+// pypiBaseURL is the base of PyPI's per-release JSON API, overridable in
+// tests.
+var pypiBaseURL = "https://pypi.org/pypi"
+
 // readReleaseVersion reads a pinned version from a release file.
 // Lines starting with "#" and blank lines are skipped.
 // A leading "v" is NOT stripped (callers decide).
@@ -491,16 +495,124 @@ func splitRequirements(requirementsFile string) (pypi, source []string, err erro
 	return pypi, source, nil
 }
 
+// parsePackageFilename extracts the PyPI project name and version from a
+// downloaded wheel (PEP 427/600) or sdist (PEP 625) filename, so a file with
+// no other attached metadata can be looked up against PyPI's per-release
+// file index. Both formats start with "<name>-<version>", with the name
+// normalized ('-', '.' collapsed to '_'); everything after the version is
+// build/interpreter/platform tags (wheels) or the ".tar.gz" suffix (sdists).
+func parsePackageFilename(filename string) (name, version string, err error) {
+	switch {
+	case strings.HasSuffix(filename, ".whl"):
+		parts := strings.Split(strings.TrimSuffix(filename, ".whl"), "-")
+		if len(parts) < 5 {
+			return "", "", fmt.Errorf("malformed wheel filename: %s", filename)
+		}
+		name, version = parts[0], parts[1]
+	case strings.HasSuffix(filename, ".tar.gz"):
+		base := strings.TrimSuffix(filename, ".tar.gz")
+		idx := strings.LastIndex(base, "-")
+		if idx < 0 {
+			return "", "", fmt.Errorf("malformed sdist filename: %s", filename)
+		}
+		name, version = base[:idx], base[idx+1:]
+	default:
+		return "", "", fmt.Errorf("unrecognized package file type: %s", filename)
+	}
+	// PyPI's JSON API resolves any of the project's registered name spellings,
+	// but the filename form always uses underscores; converting back to
+	// hyphens matches how PyPI project names are conventionally written.
+	return strings.ReplaceAll(name, "_", "-"), version, nil
+}
+
+// pypiRelease is the subset of PyPI's "/pypi/<name>/<version>/json" response
+// needed to look up a published file's digest.
+type pypiRelease struct {
+	Urls []struct {
+		Filename string `json:"filename"`
+		Digests  struct {
+			SHA256 string `json:"sha256"`
+		} `json:"digests"`
+	} `json:"urls"`
+}
+
+// fetchPyPIDigest fetches the sha256 digest PyPI itself published for a
+// given project release file, straight from PyPI's JSON API — the same
+// trust model downloadDotnetAgent uses for the .NET checksums.txt: the
+// expected digest is fetched fresh from the upstream registry for the
+// resolved version, not stored in this repo, so a compromised or corrupted
+// download can be caught without any local hash to maintain.
+func fetchPyPIDigest(name, version, filename string) (string, error) {
+	url := fmt.Sprintf("%s/%s/%s/json", pypiBaseURL, name, version)
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("fetching PyPI metadata for %s==%s: %w", name, version, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("fetching PyPI metadata for %s==%s: HTTP %d", name, version, resp.StatusCode)
+	}
+
+	var rel pypiRelease
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return "", fmt.Errorf("decoding PyPI metadata for %s==%s: %w", name, version, err)
+	}
+	for _, u := range rel.Urls {
+		if u.Filename != filename {
+			continue
+		}
+		if u.Digests.SHA256 == "" {
+			return "", fmt.Errorf("PyPI metadata for %s has no sha256 digest", filename)
+		}
+		return u.Digests.SHA256, nil
+	}
+	return "", fmt.Errorf("PyPI metadata for %s==%s has no entry for %s", name, version, filename)
+}
+
+// verifyPyPIDownloads checks every file pip downloaded into dir against the
+// sha256 digest PyPI published for that exact release file. Because the
+// files are named after the package pip download actually resolved, this
+// covers the full dependency closure (transitive dependencies included), not
+// just the packages explicitly pinned in requirements.txt.
+func verifyPyPIDownloads(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("reading downloaded packages: %w", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		filename := e.Name()
+		name, version, err := parsePackageFilename(filename)
+		if err != nil {
+			return err
+		}
+		want, err := fetchPyPIDigest(name, version, filename)
+		if err != nil {
+			return err
+		}
+		if err := verifyFileSHA256(filepath.Join(dir, filename), want); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // downloadPythonAgent installs Python auto-instrumentation packages into destDir.
 // The packages are defined by packaging/common/python/requirements.txt.
 //
 // Installation happens in two passes so the resulting package is correct for the
 // target Linux architecture and Python version regardless of the build host:
 //
-//  1. PyPI requirements are installed binary-only, pinned to manylinux wheels for
+//  1. PyPI requirements are fetched binary-only, pinned to manylinux wheels for
 //     the target arch and to the target Python version/ABI. This prevents the
 //     build host's OS (e.g. macOS) and Python version from leaking compiled
-//     extensions into the package.
+//     extensions into the package. Every resolved file (pinned requirements and
+//     their transitive dependencies alike) is downloaded to a local cache and
+//     verified against PyPI's own published sha256 digest before anything is
+//     installed; installation then proceeds --no-index from that verified
+//     cache, so a mismatched file can never be silently installed.
 //  2. Source requirements (unpublished pure-Python packages, vendored under
 //     vendor/ or on a git branch) are built from source with --no-deps into a
 //     separate directory, then merged in. Their dependencies must therefore be
@@ -523,7 +635,6 @@ func downloadPythonAgent(cfg Config, destDir string) error {
 
 	python := pythonExecutable()
 
-	// Pass 1: PyPI requirements as cross-platform manylinux wheels.
 	fmt.Printf("  Installing Python OTel packages (PyPI, linux/%s, py%s) into %s\n", cfg.Arch, targetPythonVersion, destDir)
 
 	pypiReqFile := filepath.Join(filepath.Dir(destDir), "requirements-pypi.txt")
@@ -531,11 +642,7 @@ func downloadPythonAgent(cfg Config, destDir string) error {
 		return fmt.Errorf("writing PyPI requirements file: %w", err)
 	}
 
-	pass1Args := []string{
-		"-m", "pip", "install",
-		"--target", destDir,
-		"--no-compile",
-		"--quiet",
+	platformArgs := []string{
 		"--only-binary=:all:",
 		"--python-version", targetPythonVersion,
 		"--implementation", "cp",
@@ -544,11 +651,47 @@ func downloadPythonAgent(cfg Config, destDir string) error {
 		"--abi", "none",
 	}
 	for _, p := range platforms {
-		pass1Args = append(pass1Args, "--platform", p)
+		platformArgs = append(platformArgs, "--platform", p)
 	}
-	pass1Args = append(pass1Args, "-r", pypiReqFile)
 
-	if err := runPip(python, pass1Args); err != nil {
+	// Pass 1a: download the full resolved closure into a local cache and
+	// verify it before anything is installed.
+	downloadDir, err := os.MkdirTemp("", "otel-python-download-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(downloadDir)
+
+	downloadArgs := []string{
+		"-m", "pip", "download",
+		"--dest", downloadDir,
+		"--quiet",
+	}
+	downloadArgs = append(downloadArgs, platformArgs...)
+	downloadArgs = append(downloadArgs, "-r", pypiReqFile)
+
+	if err := runPip(python, downloadArgs); err != nil {
+		return err
+	}
+
+	if err := verifyPyPIDownloads(downloadDir); err != nil {
+		return fmt.Errorf("verifying downloaded Python packages: %w", err)
+	}
+
+	// Pass 1b: install from the verified local cache only. --no-index means
+	// pip cannot fall back to re-fetching a file that was never checked.
+	installArgs := []string{
+		"-m", "pip", "install",
+		"--target", destDir,
+		"--no-compile",
+		"--quiet",
+		"--no-index",
+		"--find-links", downloadDir,
+	}
+	installArgs = append(installArgs, platformArgs...)
+	installArgs = append(installArgs, "-r", pypiReqFile)
+
+	if err := runPip(python, installArgs); err != nil {
 		return err
 	}
 

--- a/packaging/builder/download_test.go
+++ b/packaging/builder/download_test.go
@@ -172,3 +172,146 @@ func TestFetchGitHubAssetDigestHTTPError(t *testing.T) {
 		t.Fatal("fetchGitHubAssetDigest: expected error on HTTP 404, got nil")
 	}
 }
+
+func TestParsePackageFilename(t *testing.T) {
+	tests := []struct {
+		filename    string
+		wantName    string
+		wantVersion string
+	}{
+		{"opentelemetry_instrumentation-0.65b0-py3-none-any.whl", "opentelemetry-instrumentation", "0.65b0"},
+		{"opentelemetry_instrumentation-0.65b0.tar.gz", "opentelemetry-instrumentation", "0.65b0"},
+		{"protobuf-5.29.3-cp310-abi3-win_amd64.whl", "protobuf", "5.29.3"},
+		{"typing_extensions-4.12.2-py3-none-any.whl", "typing-extensions", "4.12.2"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.filename, func(t *testing.T) {
+			name, version, err := parsePackageFilename(tt.filename)
+			if err != nil {
+				t.Fatalf("parsePackageFilename(%q): %v", tt.filename, err)
+			}
+			if name != tt.wantName || version != tt.wantVersion {
+				t.Errorf("parsePackageFilename(%q) = (%q, %q), want (%q, %q)", tt.filename, name, version, tt.wantName, tt.wantVersion)
+			}
+		})
+	}
+
+	t.Run("unrecognized extension", func(t *testing.T) {
+		if _, _, err := parsePackageFilename("package-1.0.0.zip"); err == nil {
+			t.Error("parsePackageFilename: expected error for unrecognized extension, got nil")
+		}
+	})
+
+	t.Run("malformed wheel", func(t *testing.T) {
+		if _, _, err := parsePackageFilename("onlyname.whl"); err == nil {
+			t.Error("parsePackageFilename: expected error for malformed wheel filename, got nil")
+		}
+	})
+}
+
+func TestFetchPyPIDigest(t *testing.T) {
+	const filename = "opentelemetry_instrumentation-0.65b0-py3-none-any.whl"
+	const digest = "ea967a72b9939b5fcfdad572753b4306c59dcb99e3f382d95dae04286805e137"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/opentelemetry-instrumentation/0.65b0/json" {
+			http.NotFound(w, r)
+			return
+		}
+		fmt.Fprintf(w, `{"urls":[{"filename":%q,"digests":{"sha256":%q}}]}`, filename, digest)
+	}))
+	defer srv.Close()
+
+	origBase := pypiBaseURL
+	pypiBaseURL = srv.URL
+	defer func() { pypiBaseURL = origBase }()
+
+	got, err := fetchPyPIDigest("opentelemetry-instrumentation", "0.65b0", filename)
+	if err != nil {
+		t.Fatalf("fetchPyPIDigest: %v", err)
+	}
+	if got != digest {
+		t.Errorf("fetchPyPIDigest = %q, want %q", got, digest)
+	}
+}
+
+func TestFetchPyPIDigestNoMatchingFile(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"urls":[{"filename":"other-file.whl","digests":{"sha256":"deadbeef"}}]}`)
+	}))
+	defer srv.Close()
+
+	origBase := pypiBaseURL
+	pypiBaseURL = srv.URL
+	defer func() { pypiBaseURL = origBase }()
+
+	if _, err := fetchPyPIDigest("pkg", "1.0.0", "pkg-1.0.0-py3-none-any.whl"); err == nil {
+		t.Error("fetchPyPIDigest: expected error when no url entry matches the filename, got nil")
+	}
+}
+
+func TestFetchPyPIDigestHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	origBase := pypiBaseURL
+	pypiBaseURL = srv.URL
+	defer func() { pypiBaseURL = origBase }()
+
+	if _, err := fetchPyPIDigest("pkg", "1.0.0", "pkg-1.0.0-py3-none-any.whl"); err == nil {
+		t.Fatal("fetchPyPIDigest: expected error on HTTP 404, got nil")
+	}
+}
+
+func TestVerifyPyPIDownloads(t *testing.T) {
+	const filename = "pkg-1.0.0-py3-none-any.whl"
+	content := []byte("wheel contents")
+	sum := sha256.Sum256(content)
+	digest := hex.EncodeToString(sum[:])
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/pkg/1.0.0/json" {
+			http.NotFound(w, r)
+			return
+		}
+		fmt.Fprintf(w, `{"urls":[{"filename":%q,"digests":{"sha256":%q}}]}`, filename, digest)
+	}))
+	defer srv.Close()
+
+	origBase := pypiBaseURL
+	pypiBaseURL = srv.URL
+	defer func() { pypiBaseURL = origBase }()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, filename), content, 0o644); err != nil {
+		t.Fatalf("writing test file: %v", err)
+	}
+
+	if err := verifyPyPIDownloads(dir); err != nil {
+		t.Errorf("verifyPyPIDownloads: %v", err)
+	}
+}
+
+func TestVerifyPyPIDownloadsMismatch(t *testing.T) {
+	const filename = "pkg-1.0.0-py3-none-any.whl"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"urls":[{"filename":%q,"digests":{"sha256":"0000000000000000000000000000000000000000000000000000000000000"}}]}`, filename)
+	}))
+	defer srv.Close()
+
+	origBase := pypiBaseURL
+	pypiBaseURL = srv.URL
+	defer func() { pypiBaseURL = origBase }()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, filename), []byte("tampered contents"), 0o644); err != nil {
+		t.Fatalf("writing test file: %v", err)
+	}
+
+	if err := verifyPyPIDownloads(dir); err == nil {
+		t.Error("verifyPyPIDownloads: expected error on checksum mismatch, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

`downloadPythonAgent` installs wheels/sdists straight from PyPI with no integrity check beyond TLS. PyPI publishes a sha256 digest for every release file via its JSON API, so this downloads the resolved dependency closure (pinned requirements and their transitive dependencies alike) into a local cache first, verifies every file against PyPI's own published digest, and only then installs `--no-index` from that verified cache — the same trust model `downloadDotnetAgent` (#76) uses for the .NET `checksums.txt`: the expected digest is fetched fresh from the upstream registry for the resolved version rather than stored in this repo, so Renovate only needs to keep bumping `requirements.txt`.

Unlike the Java agent JAR / .NET zips (raw GitHub release binaries with no built-in checksums), and unlike a static `checksums.txt` published by opentelemetry-python's own release workflow, PyPI already publishes a checksum for every file it hosts — so this covers the whole resolved bundle, including transitive dependencies that aren't explicitly pinned in `requirements.txt`, with no changes needed upstream.

Related to #21.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [x] `go test ./packaging/builder/...` (new unit tests for filename parsing, PyPI digest lookup, and cache verification, plus existing tests)
- [ ] Docker-based integration tests (`packaging/tests/python`) — not runnable in this sandbox (no Docker access); exercised by CI