### PR TITLE
Verify injector and Java agent downloads against GitHub's asset digest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,11 @@ jobs:
           ARCH: ${{ matrix.ARCH }}
           SYS_PACKAGE: ${{ matrix.SYS_PACKAGE }}
           VERSION: ${{ steps.version.outputs.version }}
+          # Raises the GitHub API rate limit for the release-asset digest
+          # lookups in downloadInjector/downloadJavaAgent from 60/hour
+          # (shared across the whole runner IP range) to 5000/hour. Only
+          # reads public release metadata; no elevated permissions needed.
+          GITHUB_TOKEN: ${{ github.token }}
         run: make "${SYS_PACKAGE}-packages" ARCH="${ARCH}" VERSION="${VERSION}"
 
       - name: Upload artifacts

--- a/packaging/builder/download.go
+++ b/packaging/builder/download.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -26,6 +27,61 @@ const npmTimeout = 10 * time.Minute
 // httpClient is used for all artifact downloads. It sets a generous timeout
 // to avoid hanging indefinitely on stalled upstream responses.
 var httpClient = &http.Client{Timeout: 10 * time.Minute}
+
+// githubAPIBaseURL is the base of the GitHub REST API, overridable in tests.
+var githubAPIBaseURL = "https://api.github.com"
+
+// fetchGitHubAssetDigest returns the sha256 digest GitHub itself computed
+// for a release asset when it was uploaded, via the Releases API. This lets
+// a download be verified without depending on the upstream project
+// publishing its own checksum manifest — GitHub attaches this digest to
+// every asset of every public release regardless.
+//
+// A GITHUB_TOKEN in the environment is sent as a bearer token to raise the
+// otherwise very low (60/hour, shared across the whole CI runner IP range)
+// unauthenticated rate limit; it is not required for public repositories.
+func fetchGitHubAssetDigest(owner, repo, tag, assetName string) (string, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/releases/tags/%s", githubAPIBaseURL, owner, repo, tag)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "opentelemetry-packaging")
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetching release metadata for %s/%s@%s: %w", owner, repo, tag, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("fetching release metadata for %s/%s@%s: HTTP %d", owner, repo, tag, resp.StatusCode)
+	}
+
+	var release struct {
+		Assets []struct {
+			Name   string `json:"name"`
+			Digest string `json:"digest"`
+		} `json:"assets"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return "", fmt.Errorf("decoding release metadata for %s/%s@%s: %w", owner, repo, tag, err)
+	}
+	for _, a := range release.Assets {
+		if a.Name != assetName {
+			continue
+		}
+		digest, ok := strings.CutPrefix(a.Digest, "sha256:")
+		if !ok || digest == "" {
+			return "", fmt.Errorf("release asset %s has no sha256 digest", assetName)
+		}
+		return digest, nil
+	}
+	return "", fmt.Errorf("release %s/%s@%s has no asset named %s", owner, repo, tag, assetName)
+}
 
 // readReleaseVersion reads a pinned version from a release file.
 // Lines starting with "#" and blank lines are skipped.
@@ -138,24 +194,49 @@ func verifyFileSHA256(path, want string) error {
 	return nil
 }
 
-// downloadInjector fetches libotelinject.so from GitHub releases.
+// downloadInjector fetches libotelinject.so from GitHub releases and verifies
+// it against the sha256 digest GitHub itself published for that asset.
 func downloadInjector(cfg Config, dest string) error {
 	tag, err := readReleaseVersion(filepath.Join(cfg.PackagingDir, "common", "injector", "release.txt"))
 	if err != nil {
 		return err
 	}
-	url := fmt.Sprintf("https://github.com/open-telemetry/opentelemetry-injector/releases/download/%s/libotelinject_%s.so", tag, cfg.Arch)
-	return downloadFile(url, dest)
+	const owner, repo = "open-telemetry", "opentelemetry-injector"
+	assetName := fmt.Sprintf("libotelinject_%s.so", cfg.Arch)
+
+	want, err := fetchGitHubAssetDigest(owner, repo, tag, assetName)
+	if err != nil {
+		return fmt.Errorf("fetching asset digest: %w", err)
+	}
+
+	url := fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s", owner, repo, tag, assetName)
+	if err := downloadFile(url, dest); err != nil {
+		return err
+	}
+	return verifyFileSHA256(dest, want)
 }
 
-// downloadJavaAgent fetches the Java agent JAR from GitHub releases.
+// downloadJavaAgent fetches the Java agent JAR from GitHub releases and
+// verifies it against the sha256 digest GitHub itself published for that
+// asset.
 func downloadJavaAgent(cfg Config, dest string) error {
 	tag, err := readReleaseVersion(filepath.Join(cfg.PackagingDir, "common", "java", "release.txt"))
 	if err != nil {
 		return err
 	}
-	url := fmt.Sprintf("https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/%s/opentelemetry-javaagent.jar", tag)
-	return downloadFile(url, dest)
+	const owner, repo = "open-telemetry", "opentelemetry-java-instrumentation"
+	const assetName = "opentelemetry-javaagent.jar"
+
+	want, err := fetchGitHubAssetDigest(owner, repo, tag, assetName)
+	if err != nil {
+		return fmt.Errorf("fetching asset digest: %w", err)
+	}
+
+	url := fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s", owner, repo, tag, assetName)
+	if err := downloadFile(url, dest); err != nil {
+		return err
+	}
+	return verifyFileSHA256(dest, want)
 }
 
 // downloadNodejsAgent fetches the Node.js auto-instrumentation from npm.

--- a/packaging/builder/download_test.go
+++ b/packaging/builder/download_test.go
@@ -6,6 +6,7 @@ package builder
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -92,4 +93,82 @@ func TestVerifyFileSHA256(t *testing.T) {
 			t.Error("verifyFileSHA256: expected error for missing file, got nil")
 		}
 	})
+}
+
+func TestFetchGitHubAssetDigest(t *testing.T) {
+	const digest = "1457e82f86981ae7af77a06add85eae0c8e6cf0c91d58eb948d4e5af160cff6"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/open-telemetry/opentelemetry-injector/releases/tags/v0.11.0" {
+			http.NotFound(w, r)
+			return
+		}
+		fmt.Fprintf(w, `{"assets":[
+			{"name":"libotelinject_amd64.so","digest":"sha256:%s"},
+			{"name":"libotelinject_arm64.so","digest":"sha256:deadbeef"}
+		]}`, digest)
+	}))
+	defer srv.Close()
+
+	origBase := githubAPIBaseURL
+	githubAPIBaseURL = srv.URL
+	defer func() { githubAPIBaseURL = origBase }()
+
+	got, err := fetchGitHubAssetDigest("open-telemetry", "opentelemetry-injector", "v0.11.0", "libotelinject_amd64.so")
+	if err != nil {
+		t.Fatalf("fetchGitHubAssetDigest: %v", err)
+	}
+	if got != digest {
+		t.Errorf("fetchGitHubAssetDigest = %q, want %q", got, digest)
+	}
+}
+
+func TestFetchGitHubAssetDigestSendsToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization header = %q, want %q", got, "Bearer test-token")
+		}
+		fmt.Fprint(w, `{"assets":[{"name":"asset.bin","digest":"sha256:deadbeef"}]}`)
+	}))
+	defer srv.Close()
+
+	origBase := githubAPIBaseURL
+	githubAPIBaseURL = srv.URL
+	defer func() { githubAPIBaseURL = origBase }()
+
+	t.Setenv("GITHUB_TOKEN", "test-token")
+
+	if _, err := fetchGitHubAssetDigest("owner", "repo", "v1.0.0", "asset.bin"); err != nil {
+		t.Fatalf("fetchGitHubAssetDigest: %v", err)
+	}
+}
+
+func TestFetchGitHubAssetDigestNoMatchingAsset(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"assets":[{"name":"other-asset.bin","digest":"sha256:deadbeef"}]}`)
+	}))
+	defer srv.Close()
+
+	origBase := githubAPIBaseURL
+	githubAPIBaseURL = srv.URL
+	defer func() { githubAPIBaseURL = origBase }()
+
+	if _, err := fetchGitHubAssetDigest("owner", "repo", "v1.0.0", "asset.bin"); err == nil {
+		t.Error("fetchGitHubAssetDigest: expected error when no asset matches the name, got nil")
+	}
+}
+
+func TestFetchGitHubAssetDigestHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	origBase := githubAPIBaseURL
+	githubAPIBaseURL = srv.URL
+	defer func() { githubAPIBaseURL = origBase }()
+
+	if _, err := fetchGitHubAssetDigest("owner", "repo", "v1.0.0", "asset.bin"); err == nil {
+		t.Fatal("fetchGitHubAssetDigest: expected error on HTTP 404, got nil")
+	}
 }


### PR DESCRIPTION
## Summary

`downloadInjector` and `downloadJavaAgent` downloaded a raw GitHub release asset with no integrity check beyond TLS. GitHub computes and publishes a sha256 `digest` for every release asset via its Releases API (`GET /repos/{owner}/{repo}/releases/tags/{tag}`), regardless of whether the upstream project publishes its own checksum manifest — confirmed live against both `opentelemetry-injector` and `opentelemetry-java-instrumentation` releases. This fetches that digest and verifies the download before use, the same pattern `downloadDotnetAgent` uses for the .NET `checksums.txt`, just sourced from GitHub's platform metadata instead of a project-authored file.

This closes both gaps immediately and doesn't depend on open-telemetry/opentelemetry-java-instrumentation#19914 (adding a `checksums.txt` to the Java release) landing first — that PR is still worth having for a human-auditable, project-authored manifest as defense in depth, but `download.go` no longer needs to wait on it.

Also threads `GITHUB_TOKEN` into the `build-packages` workflow step so the new digest lookups run authenticated (5000/hour) rather than the 60/hour unauthenticated limit, which is shared across the whole GitHub Actions runner IP range and would be fragile under concurrent CI load.

Related to #21.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [x] `go test ./packaging/builder/...` (new unit tests for `fetchGitHubAssetDigest`, including token propagation, no-match, and HTTP-error cases, plus existing tests)
- [x] YAML syntax of the updated workflow validated
- [ ] Docker-based integration tests (`packaging/tests/java`, `packaging/tests/injector`-adjacent) — not runnable in this sandbox (no Docker access); exercised by CI