### PR TITLE
fix(python): deactivate when auto-instrumentation initialization fails

### DIFF
--- a/packaging/common/python/README.md
+++ b/packaging/common/python/README.md
@@ -80,6 +80,12 @@ export OTEL_CONFIG_FILE=/etc/opentelemetry/python/otel-config.yaml
    general-purpose libraries (PyYAML, jsonschema) where the application's version is
    expected to keep working: those log a warning instead.
 
+Once those pass, a failure during activation itself also self-deactivates, with the error
+reported on one line. This covers what the checks above cannot foresee, such as a
+configuration file that `otel-config-check` accepts and the SDK's file configurator then
+rejects: the validator checks the YAML and `file_format`, while the SDK validates the whole
+document against its schema.
+
 ## Supported libraries
 
 Instrumentation plug-ins are included for:

--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -323,7 +323,14 @@ def import_distro():
         try:
             _log_debug("importing and initializing the Python auto-instrumentation now")
             from opentelemetry.instrumentation import auto_instrumentation
-            auto_instrumentation.initialize()
+            # swallow_exceptions=False is what makes the handler below reachable.
+            # initialize() defaults to logging any failure of the distro, the
+            # configurators, or the instrumentors and returning normally, which
+            # would leave this site activated around an SDK that never
+            # initialized: no telemetry, no message from us, and every child
+            # process repeating it. The parameter exists since
+            # opentelemetry-instrumentation 0.55b0.
+            auto_instrumentation.initialize(swallow_exceptions=False)
         except Exception as e:
             _self_deactivate(current_site)
             _print_cannot_auto_instrument_message(

--- a/packaging/common/python/test_sitecustomize.py
+++ b/packaging/common/python/test_sitecustomize.py
@@ -203,6 +203,7 @@ class ImportDistroTests(unittest.TestCase):
         installed_version="1.0.0",
         installed_distributions=None,
         sys_path_entry=None,
+        initialize_side_effect=None,
     ):
         """Execute sitecustomize.py end to end.
 
@@ -211,6 +212,9 @@ class ImportDistroTests(unittest.TestCase):
         auto-instrumentation entry point is replaced with a mock, and the host
         is hidden: no installed distributions, and every requirement resolves
         to installed_version.
+
+        initialize_side_effect makes the mocked initialize() raise, which is
+        how the SDK reports a failure it cannot recover from.
 
         Returns (stderr output, auto_instrumentation mock, environment
         observed right after the run).
@@ -225,6 +229,7 @@ class ImportDistroTests(unittest.TestCase):
             return real_dirname(p)
 
         auto_instrumentation = MagicMock()
+        auto_instrumentation.initialize.side_effect = initialize_side_effect
         instrumentation_pkg = MagicMock()
         instrumentation_pkg.auto_instrumentation = auto_instrumentation
 
@@ -265,10 +270,16 @@ class ImportDistroTests(unittest.TestCase):
         auto_instrumentation.initialize.assert_called_once_with()
         self.assertIn(self.site_dir, observed_env["PYTHONPATH"])
 
-    def _assert_deactivated(self, auto_instrumentation, observed_env):
-        auto_instrumentation.initialize.assert_not_called()
+    def _assert_deactivated_environment(self, observed_env):
+        # What a deactivation must leave behind, whichever guard performed it:
+        # the site gone from PYTHONPATH and the injector's agent path cleared,
+        # so no child process retries the activation.
         self.assertEqual(self.OTHER_PYTHONPATH_ENTRY, observed_env["PYTHONPATH"])
         self.assertEqual("", observed_env["PYTHON_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX"])
+
+    def _assert_deactivated(self, auto_instrumentation, observed_env):
+        auto_instrumentation.initialize.assert_not_called()
+        self._assert_deactivated_environment(observed_env)
 
     def test_initializes_when_all_dependencies_match(self):
         output, auto_instrumentation, observed_env = self._exec_sitecustomize(
@@ -389,6 +400,23 @@ class ImportDistroTests(unittest.TestCase):
         )
         self._assert_initialized(auto_instrumentation, observed_env)
         self.assertIn("cannot run otel-config-check", output)
+
+    def test_deactivates_when_initialize_raises(self):
+        # Initialization is the one stage this module does not perform itself,
+        # so the handler around initialize() is what turns a failure inside the
+        # SDK into a deactivation. A configuration file that otel-config-check
+        # accepts and the file configurator then rejects arrives here: the
+        # validator only checks the YAML and file_format, the SDK validates the
+        # whole document against its schema.
+        self._write_fake_validator(exit_code=0)
+        output, auto_instrumentation, observed_env = self._exec_sitecustomize(
+            extra_env={"OTEL_CONFIG_FILE": os.path.join(self.base_dir, "otel-config.yaml")},
+            all_dependencies="foo==1.0.0\n",
+            initialize_side_effect=ValueError("'file_format' is a required property"),
+        )
+        self._assert_deactivated_environment(observed_env)
+        self.assertIn("error when importing/initializing", output)
+        self.assertIn("ValueError: 'file_format' is a required property", output)
 
     def test_deactivates_on_double_instrumentation(self):
         dist = MagicMock()

--- a/packaging/common/python/test_sitecustomize.py
+++ b/packaging/common/python/test_sitecustomize.py
@@ -257,7 +257,7 @@ class ImportDistroTests(unittest.TestCase):
     def _assert_activated(
         self, auto_instrumentation, observed_env, exporter="otlp_proto_http"
     ):
-        auto_instrumentation.initialize.assert_called_once_with()
+        auto_instrumentation.initialize.assert_called_once_with(swallow_exceptions=False)
         self.assertIn(self.site_dir, observed_env["PYTHONPATH"])
         self.assertEqual(exporter, observed_env["OTEL_TRACES_EXPORTER"])
         self.assertEqual(exporter, observed_env["OTEL_METRICS_EXPORTER"])
@@ -267,7 +267,7 @@ class ImportDistroTests(unittest.TestCase):
         # Activation without asserting exporter selection: under OTEL_CONFIG_FILE
         # the configuration file drives the exporter and sitecustomize leaves
         # OTEL_*_EXPORTER untouched.
-        auto_instrumentation.initialize.assert_called_once_with()
+        auto_instrumentation.initialize.assert_called_once_with(swallow_exceptions=False)
         self.assertIn(self.site_dir, observed_env["PYTHONPATH"])
 
     def _assert_deactivated_environment(self, observed_env):


### PR DESCRIPTION
Fixes #93.

`sitecustomize.py` called `auto_instrumentation.initialize()` with no arguments, so it got the default `swallow_exceptions=True`. `_initialize` in contrib wraps the distro, the configurators, and the instrumentors in a broad handler that logs the failure and returns normally, so our own handler around the call never saw it. The `import` on the line above was the only thing it still covered.

The effect was that a failure during activation left the process in the one state the guards exist to prevent: the site still on `sys.path` and in `PYTHONPATH`, `PYTHON_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX` still set, an SDK that never initialized, no `[opentelemetry-python-autoinstrumentation]` message, and every child process repeating it.

The clearest way to reach it is a declarative configuration file that `otel-config-check` accepts and the SDK then rejects. That is not a validator defect: it checks the YAML and `file_format` by design, while the SDK validates the whole document against its schema.

## Verified against the pinned packages

Not just against the mocked entry point. A bundle-shaped layout with `opentelemetry-instrumentation` 0.65b0, `opentelemetry-sdk` 1.44.0 and `opentelemetry-configuration` 0.65b0, `otel-config-check` present and exiting 0, and `OTEL_CONFIG_FILE` pointing at:

```yaml
file_format: "1.0"
tracer_provider: 42
```

| | before | after |
|---|---|---|
| site in `PYTHONPATH` | still present | removed |
| `PYTHON_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX` | still set | cleared |
| site on `sys.path` | still present | removed |
| `opentelemetry` modules in `sys.modules` | 139 | 139 |
| tracer provider | `ProxyTracerProvider` | none |
| `[opentelemetry-python-autoinstrumentation]` lines | 0 | 1 |
| application exit code | 0 | 0 |

The message the application's operator now gets:

```
[opentelemetry-python-autoinstrumentation] WARN: cannot auto-instrument Python process: error when importing/initializing Python OpenTelemetry auto-instrumentation: ConfigurationError: Configuration does not match schema: 42 is not of type 'object' (at tracer_provider) [...]
```

## Commits

1. `test(python)`: the handler around `initialize()` had no test, because the mocked entry point never failed. Adds an `initialize_side_effect` hook to the harness and a test, and splits the environment half of `_assert_deactivated` out so a guard that does call `initialize()` can reuse it. This commit passes before the fix.
2. `fix(python)`: pass `swallow_exceptions=False`. Two assertions in the harness move to the new call signature.
3. `docs(python)`: the safety-guard list in the README stopped at the checks performed before activation.

## Notes for review

**The parameter is available.** `swallow_exceptions` exists since `opentelemetry-instrumentation` v0.55b0 and we pin 0.65b0, so there is no version floor to raise.

**Known trade-off, worth a second opinion.** This also propagates from `_load_instrumentors`, whose final handler re-raises after earlier instrumentation plug-ins have already patched the process. `_self_deactivate` cleans `sys.path` and the environment, so children are protected, but it cannot unpatch what is already applied. I think deactivating is still right, since a process whose instrumentation failed halfway is not a state worth keeping, but the alternative is to keep swallowing for that phase only, which needs a change in contrib.

**Residual noise, not fixed here.** contrib calls `_logger.exception` and then re-raises, so the failure is reported twice: once as a traceback through the `logging` module, once as our warning. That measured 9.9 KB of stderr for the file above, and 1.4 MB for a file missing `file_format`, because `jsonschema` embeds the whole configuration schema in that error. Moving the log into the swallow branch would be a tidy upstream fix.

**Test coverage this PR does not add.** The unit suite mocks `initialize`, so it can only assert that the keyword is passed. Proving the propagation needs the real bundle, which means the container suites. `TestPythonDeclarativeConfiguration` already covers `OTEL_CONFIG_FILE` with a good file, and a bad-file variant belongs next to it: assert the workload still answers on 8080, that the warning appears in the container logs, and that no spans reach the sink. That needs a negative sink assertion helper, so I left it out of this PR rather than half-doing it. The table above is the manual equivalent.

What CI does confirm on this branch: every `integration-tests (deb|rpm, python, amd64|arm64)` job passes, including `TestPythonDeclarativeConfiguration`, so a good configuration file still activates normally with `swallow_exceptions=False`. Only the negative case is untested.

**Still open, separately.** When `otel-config-check` is missing or cannot be executed, `_validate_config_file` returns `None` and the caller reads that as "the file is fine". With this PR that no longer ends in a silent hole, but the return value still conflates "verified good" with "never checked". I will file that on its own.
