### PR TITLE
refactor(python): carry the diagnostics severity as a logging level

### DIFF
--- a/packaging/common/python/README.md
+++ b/packaging/common/python/README.md
@@ -51,6 +51,27 @@ exporters (they emit protobuf only).
 - `OTEL_PYTHON_DISABLED_INSTRUMENTATIONS`: Comma-separated list of instrumentations to disable
 - `OTEL_INJECTOR_LOG_LEVEL`: Set to `debug` for verbose sitecustomize.py logging
 
+### Diagnostics
+
+`sitecustomize.py` reports on standard error, one line per record, prefixed with
+`[opentelemetry-python-autoinstrumentation]` and the severity of the record:
+
+```
+[opentelemetry-python-autoinstrumentation] WARNING: cannot auto-instrument Python process: ...
+```
+
+A `WARNING` is always emitted, and it is the only report you get when a safety
+guard deactivates the agent. `DEBUG` records are emitted only when
+`OTEL_INJECTOR_LOG_LEVEL=debug`.
+
+The records are `logging` records at `logging.WARNING` and `logging.DEBUG`, but
+they never enter the application's logging. The agent runs during `site` import,
+before the application's first line, so it writes through a logger of its own
+that is not registered in `logging.Logger.manager.loggerDict` and has no path to
+the root handlers. It configures no handler, level, or filter that the
+application can observe, and it does not import `logging` at all unless it has
+something to report.
+
 ### Declarative configuration
 
 A working declarative configuration file is installed at `/etc/opentelemetry/python/otel-config.yaml`.

--- a/packaging/common/python/opentelemetry-python.8.tmpl
+++ b/packaging/common/python/opentelemetry-python.8.tmpl
@@ -100,6 +100,15 @@ without crashing the instrumented process.
 If the application already carries OpenTelemetry SDK dependencies, the
 auto-instrumentation detects this (double-instrumentation check) and
 self-deactivates gracefully.
+.PP
+Diagnostics are written to standard error, prefixed with
+.B [opentelemetry-python-autoinstrumentation]
+and the severity of the record. A WARNING is always emitted; DEBUG records
+require
+.BR OTEL_INJECTOR_LOG_LEVEL=debug .
+They never enter the application's logging: the agent writes through a logger of
+its own and configures no handler, level, or filter that the application can
+observe.
 .SH SEE ALSO
 .BR opentelemetry-injector (8)
 .PP

--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -11,7 +11,6 @@
 # IMPORTANT: This file must be valid Python 2.7+ so that it can be parsed without crashing
 # older interpreters. The version gate below prevents execution on unsupported versions.
 
-from __future__ import print_function
 import os
 from os.path import dirname
 import sys
@@ -43,26 +42,68 @@ version_conflict_exempt_packages = [
 
 debug_enabled = os.environ.get("OTEL_INJECTOR_LOG_LEVEL") == "debug"
 
+_logger = None
 
-def _log(level, message):
-    # sys.stderr can be None (daemons, pythonw); print(file=None) would fall
-    # through to stdout and corrupt the application's output stream. Diagnostics
-    # must never do that, nor raise (e.g. on a closed fd 2).
-    if stderr is None:
-        return
-    try:
-        print("[opentelemetry-python-autoinstrumentation] {}: {}".format(level, message), file=stderr)
-    except Exception:
-        pass
+
+def _get_logger():
+    # logging is imported here rather than at module scope. The injector
+    # prepends this file to every Python process on the host, including the
+    # short-lived ones and the ones that deactivate at the version gate, and
+    # `import logging` costs 22 ms and 34 modules (threading, re, traceback)
+    # against 2.7 ms for site itself. A process that emits no diagnostic pays
+    # none of it.
+    global _logger
+    if _logger is not None:
+        return _logger
+    import logging
+
+    class _SilentStreamHandler(logging.StreamHandler):
+        # A diagnostic that cannot be written must fail silently, which is what
+        # `print(file=stderr)` wrapped in `except Exception: pass` did.
+        # Handler.handleError instead writes a "--- Logging error ---"
+        # traceback to sys.stderr, which is usually the stream that just
+        # failed, and it swallows only OSError while doing so. Subclassed
+        # rather than switching logging.raiseExceptions, which is global state
+        # the application owns.
+        def handleError(self, record):
+            pass
+
+    # Built by instantiating logging.Logger directly instead of through
+    # logging.getLogger(), so that nothing about the application's logging
+    # changes: the logger never enters logging.Logger.manager.loggerDict, so
+    # the application cannot reach it by name and dictConfig cannot disable it
+    # while disabling existing loggers, and its parent is None, so no record
+    # can reach the root handlers. getLogger() exists so that one name yields
+    # one shared logger; here not sharing is the point.
+    logger = logging.Logger("opentelemetry-python-autoinstrumentation")
+    # sys.stderr can be None (daemons, pythonw) or closed. The handler holds
+    # the stream from construction, so a later replacement cannot silence the
+    # diagnostics, and a write to a None or closed stream is dropped instead
+    # of raising or falling through to the application's stdout.
+    handler = _SilentStreamHandler(stderr)
+    handler.setFormatter(logging.Formatter(
+        "[opentelemetry-python-autoinstrumentation] %(levelname)s: %(message)s"))
+    logger.addHandler(handler)
+    # Both filters logging applies by default sit at WARNING: the level
+    # inherited from the root logger, and the level of the fallback handler
+    # (logging.lastResort, which does not exist before Python 3.2 and drops
+    # every record with a "No handlers could be found" line instead). Owning
+    # the level and the handler bypasses both, so a debug run is verbose on
+    # every interpreter this file can reach.
+    logger.setLevel(logging.DEBUG if debug_enabled else logging.WARNING)
+    _logger = logger
+    return _logger
 
 
 def _log_warn(message):
-    _log("WARN", message)
+    _get_logger().warning(message)
 
 
 def _log_debug(message):
+    # Not a level filter, the logger's own level is that. This keeps a process
+    # running with debug off from importing logging at all.
     if debug_enabled:
-        _log("DEBUG", message)
+        _get_logger().debug(message)
 
 
 _log_debug("running sitecustomize.py")

--- a/packaging/common/python/test_sitecustomize.py
+++ b/packaging/common/python/test_sitecustomize.py
@@ -468,20 +468,44 @@ class LoggingTests(unittest.TestCase):
         module._log_debug("a trace")
         self.assertEqual("", buf.getvalue())
 
-    def test_log_with_stderr_none_is_silent(self):
+    def test_suppressed_debug_record_does_not_build_the_logger(self):
+        # The guard in _log_debug is what keeps a process running with debug
+        # off from importing logging at all, which the injector cares about
+        # because it prepends this file to every Python process on the host.
         module, _ = _load_benign()
+        module._logger = None
+        module._log_debug("a trace")
+        self.assertIsNone(module._logger)
+
+    def test_log_with_stderr_none_is_silent(self):
+        # The daemon and pythonw case: sys.stderr is None at interpreter
+        # startup, so the module's own binding is None too. Nothing may be
+        # written and nothing may raise.
+        module, buf = _load_benign()
         module.stderr = None
-        module._log_warn("must not raise nor reach stdout")
+        # The load already emitted the protocol-guard warning, so the handler
+        # exists and holds the buffer. Drop it to rebuild it from the None.
+        module._logger = None
+        with patch.object(sys, "stderr", None):
+            module._log_warn("must not raise nor reach stdout")
+        self.assertEqual("", buf.getvalue())
 
     def test_log_with_broken_stderr_does_not_raise(self):
-        module, _ = _load_benign()
+        module, buf = _load_benign()
 
         class Broken(object):
             def write(self, *_args):
                 raise IOError("closed")
 
         module.stderr = Broken()
-        module._log_warn("must not raise")
+        module._logger = None
+        fallback = StringIO()
+        with patch.object(sys, "stderr", fallback):
+            module._log_warn("must not raise")
+        # A write that fails must be dropped without a word: the logging
+        # module's own error path would report it on sys.stderr instead.
+        self.assertEqual("", fallback.getvalue())
+        self.assertEqual("", buf.getvalue())
 
 
 class ApplicationLoggingTests(unittest.TestCase):

--- a/packaging/common/python/test_sitecustomize.py
+++ b/packaging/common/python/test_sitecustomize.py
@@ -12,6 +12,7 @@ Run with `make python-unit-tests`.
 
 import importlib.metadata
 import importlib.util
+import logging
 import os
 import shutil
 import sys
@@ -39,21 +40,25 @@ def _load_sitecustomize(stderr_buffer):
     return module
 
 
-def _load_benign():
+def _load_benign(extra_env=None):
     """Load sitecustomize with import_distro() short-circuiting harmlessly.
 
     An unsupported OTEL_EXPORTER_OTLP_PROTOCOL makes import_distro()
     self-deactivate at the protocol guard, before reading files or package
     metadata. os.environ and sys.path are patched so the deactivation cannot
-    leak into the test process. Returns (module, stderr buffer).
+    leak into the test process. OTEL_INJECTOR_LOG_LEVEL is dropped from the
+    inherited environment, so the diagnostics level is decided by extra_env
+    alone and not by the shell running the suite. Returns (module, stderr
+    buffer).
     """
     buf = StringIO()
     env = {
         k: v for k, v in os.environ.items()
-        if k not in ("OTEL_EXPORTER_OTLP_PROTOCOL", "OTEL_CONFIG_FILE")
+        if k not in ("OTEL_EXPORTER_OTLP_PROTOCOL", "OTEL_CONFIG_FILE", "OTEL_INJECTOR_LOG_LEVEL")
     }
     # http/json is unsupported, so the guard deactivates without side effects.
     env["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/json"
+    env.update(extra_env or {})
     with patch.dict(os.environ, env, clear=True), patch.object(sys, "path", list(sys.path)):
         module = _load_sitecustomize(buf)
     # Discard the protocol-guard warning the short circuit itself produced, so
@@ -426,7 +431,42 @@ class ImportDistroTests(unittest.TestCase):
 
 
 class LoggingTests(unittest.TestCase):
-    """The diagnostics channel must never touch stdout or raise."""
+    """The contract of the diagnostics channel.
+
+    Every line names the agent and the severity of the record, the severity
+    decides whether the line is emitted at all, and the channel never touches
+    stdout nor raises.
+    """
+
+    PREFIX = "[opentelemetry-python-autoinstrumentation]"
+
+    def test_warning_names_the_agent_and_the_severity(self):
+        module, buf = _load_benign()
+        module._log_warn("a diagnostic")
+        output = buf.getvalue()
+        self.assertIn(self.PREFIX, output)
+        self.assertIn("WARN", output)
+        self.assertIn("a diagnostic", output)
+
+    def test_warning_is_emitted_whatever_the_level(self):
+        # No value of OTEL_INJECTOR_LOG_LEVEL silences a warning: it is the
+        # only report an operator gets when the agent deactivates.
+        module, buf = _load_benign(extra_env={"OTEL_INJECTOR_LOG_LEVEL": "debug"})
+        module._log_warn("a diagnostic")
+        self.assertIn("a diagnostic", buf.getvalue())
+
+    def test_debug_names_the_agent_and_the_severity(self):
+        module, buf = _load_benign(extra_env={"OTEL_INJECTOR_LOG_LEVEL": "debug"})
+        module._log_debug("a trace")
+        output = buf.getvalue()
+        self.assertIn(self.PREFIX, output)
+        self.assertIn("DEBUG", output)
+        self.assertIn("a trace", output)
+
+    def test_debug_is_suppressed_when_the_level_is_unset(self):
+        module, buf = _load_benign()
+        module._log_debug("a trace")
+        self.assertEqual("", buf.getvalue())
 
     def test_log_with_stderr_none_is_silent(self):
         module, _ = _load_benign()
@@ -442,6 +482,49 @@ class LoggingTests(unittest.TestCase):
 
         module.stderr = Broken()
         module._log_warn("must not raise")
+
+
+class ApplicationLoggingTests(unittest.TestCase):
+    """sitecustomize.py must leave the application's logging untouched.
+
+    It runs during site import, before the application's first line, so any
+    logging state it changed would be inherited by the application: the root
+    logger's level and handlers, the registry that dictConfig walks when it
+    disables existing loggers, and the global disable threshold.
+    """
+
+    def setUp(self):
+        root = logging.getLogger()
+        self.before = (
+            set(logging.Logger.manager.loggerDict),
+            list(root.handlers),
+            root.level,
+            logging.Logger.manager.disable,
+        )
+
+    def _assert_logging_state_untouched(self):
+        root = logging.getLogger()
+        self.assertEqual(
+            self.before,
+            (
+                set(logging.Logger.manager.loggerDict),
+                list(root.handlers),
+                root.level,
+                logging.Logger.manager.disable,
+            ),
+        )
+
+    def test_running_the_module_touches_no_logging_state(self):
+        # The load emits at both severities: DEBUG for the entry trace and
+        # WARN from the protocol guard that short-circuits it.
+        _load_benign(extra_env={"OTEL_INJECTOR_LOG_LEVEL": "debug"})
+        self._assert_logging_state_untouched()
+
+    def test_emitting_after_the_load_touches_no_logging_state(self):
+        module, _ = _load_benign(extra_env={"OTEL_INJECTOR_LOG_LEVEL": "debug"})
+        module._log_debug("a trace")
+        module._log_warn("a diagnostic")
+        self._assert_logging_state_untouched()
 
 
 if __name__ == "__main__":

--- a/packaging/tests/python/Dockerfile.sitecustomize
+++ b/packaging/tests/python/Dockerfile.sitecustomize
@@ -4,6 +4,11 @@
 # Runs an unmodified Python one-liner with the packaged sitecustomize.py on
 # PYTHONPATH, the way the injector activates it. The test asserts that the
 # process always runs to completion, whatever the interpreter version.
+#
+# The one-liner configures logging its own way, at its own level and with its
+# own format. sitecustomize.py runs before it and emits diagnostics of its own,
+# so the test also asserts that the application's configuration is the one in
+# effect afterwards.
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
@@ -17,4 +22,4 @@ ENV PYTHONPATH=/otel-site
 # them. (An unset protocol now defaults to grpc and would proceed to activate.)
 ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/json
 
-CMD ["python", "-c", "print('APP RAN TO COMPLETION')"]
+CMD ["python", "-c", "import logging; logging.basicConfig(level=logging.INFO, format='APP %(levelname)s %(name)s: %(message)s'); log = logging.getLogger('myapp'); log.info('application logging is intact'); log.debug('application debug stays hidden'); print('APP RAN TO COMPLETION')"]

--- a/packaging/tests/python/sitecustomize_test.go
+++ b/packaging/tests/python/sitecustomize_test.go
@@ -8,6 +8,10 @@
 // ever breaking the application. The logic behind the guards is covered by
 // unit tests (test_sitecustomize.py next to the script); this suite covers
 // real interpreters.
+//
+// "Harmless" includes the application's logging. sitecustomize.py runs during
+// site import, before the application's first line, so anything it changed
+// about the logging module would be inherited by the application.
 package python_test
 
 import (
@@ -21,6 +25,16 @@ import (
 // appMarker is printed by the containerized application after sitecustomize.py
 // has run; its presence proves the application was not broken.
 const appMarker = "APP RAN TO COMPLETION"
+
+// appLogMarker is logged by the containerized application through its own
+// logging configuration, at its own level and in its own format. Its presence
+// proves that the diagnostics sitecustomize.py emitted first left that
+// configuration alone.
+const appLogMarker = "APP INFO myapp: application logging is intact"
+
+// appDebugMarker would only appear if something lowered the application's log
+// level below the INFO it asked for.
+const appDebugMarker = "APP DEBUG"
 
 func TestSitecustomizePythonVersionCompatibility(t *testing.T) {
 	cases := []struct {
@@ -67,6 +81,10 @@ func TestSitecustomizePythonVersionCompatibility(t *testing.T) {
 				"the application must run to completion under %s", tc.image)
 			assert.Contains(t, output, tc.expectedGuard,
 				"expected the guard message for this interpreter")
+			assert.Contains(t, output, appLogMarker,
+				"the application's own logging configuration must be the one in effect under %s", tc.image)
+			assert.NotContains(t, output, appDebugMarker,
+				"sitecustomize.py must not lower the application's log level under %s", tc.image)
 		})
 	}
 }


### PR DESCRIPTION
Fixes #96.

`sitecustomize.py` was using the concept of severity without using the thing that represents it. It named a severity, filtered on it, formatted it into a prefix, and wrote the result with `print`:

```python
def _log(level, message):
    if stderr is None:
        return
    try:
        print("[opentelemetry-python-autoinstrumentation] {}: {}".format(level, message), file=stderr)
    except Exception:
        pass
```

That is a logger, hand-rolled from four pieces the standard library already has:

| what the code did | what implements it |
|---|---|
| named a severity (`WARN`, `DEBUG`) | `logging` levels |
| filtered by severity | `Logger.setLevel` |
| formatted a record with a fixed prefix | `logging.Formatter` |
| wrote to a stream, tolerating a `None` or broken one | `logging.StreamHandler`, `Handler.handleError` |

The severity is the load-bearing part. It is what an operator reads to tell a problem from a trace, and it is what `OTEL_INJECTOR_LOG_LEVEL` claims to select on. Expressed as a substring of a formatted line it exists only by convention, and nothing can order or compare it. This PR makes it a `logging` level.

## Why the textbook library shape does not work here

The usual advice for a library is `logging.getLogger(__name__)`, no handler, let the application decide. It fails here, silently, so it is worth stating why the handler stays ours.

`logging` applies two independent filters, both at `WARNING` by default:

1. **The inherited level.** A new logger sits at `NOTSET` and inherits from root, whose default is `WARNING`, so `log.debug(...)` returns inside `isEnabledFor` before any handler is consulted.
2. **The fallback handler.** If a record passes that and no handler is installed anywhere in the hierarchy, `callHandlers` falls back to `logging.lastResort`, a `_StderrHandler` with its own `WARNING` level and no formatter.

So `setLevel(logging.DEBUG)` alone is not enough: it opens the first gate and the second still drops the record.

On Python 2.7 it is not a degradation but a loss. There is no `lastResort` (`hasattr(logging, "lastResort")` is `False`), so with no handler the entire output is:

```
No handlers could be found for logger "opentelemetry.injector"
```

The `WARNING` is gone too. Python 2.7 is one of the interpreters this file exists to serve gracefully, `packaging/tests/python/sitecustomize_test.go` runs it there, and the version-gate message is the only thing an operator ever sees on it.

## Nothing the application can observe

The logger is built by instantiating `logging.Logger` directly rather than through `logging.getLogger`. It therefore never enters `logging.Logger.manager.loggerDict`, so the application cannot reach it by name and `dictConfig` cannot disable it while disabling existing loggers, and its `parent` is `None`, so no record can reach the root handlers. Measured footprint:

| construction | keys added to `loggerDict` |
|---|---|
| `logging.Logger("opentelemetry-python-autoinstrumentation")` | none |
| `logging.getLogger("opentelemetry-python-autoinstrumentation")` | 1 |
| `logging.getLogger("opentelemetry.injector")` | 2, including a `PlaceHolder` for `opentelemetry` |

`getLogger` exists so that one name yields one shared logger. Here not sharing is the point, so the documentation note against direct instantiation is arguing for the property we do not want.

Verified against an application that calls `basicConfig`, then `dictConfig` with a root handler and `disable_existing_loggers` at its default, and logs on `myapp`, `opentelemetry.sdk`, and root: with the injector logger built first, its stdout and stderr are byte-identical to a run without it.

## Lazy import

The injector prepends this file to every Python process on the host, including short-lived ones and ones that deactivate at the version gate. Measured with `-X importtime`, `import logging` costs 22 ms cumulative (`re` 9.1 ms, `traceback` 5.3 ms, `threading` 2.4 ms) against 2.7 ms for `site` itself, pulls in 34 modules, and registers `atexit.register(shutdown)`.

So it is imported inside `_get_logger`, and the `debug_enabled` guard in `_log_debug` stays, no longer as a level filter but so that a process running with debug off never imports `logging` at all. A successful activation emits nothing and pays nothing.

## Verified

Run as a real `sitecustomize.py` on `PYTHONPATH` against `python:2.7-slim`, `3.9-slim`, `3.10-slim`, `3.13-slim`, and `3.14-slim`, with `OTEL_INJECTOR_LOG_LEVEL` unset and set to `debug`, and the diagnostic output diffed against `upstream/main`:

| | before | after |
|---|---|---|
| `DEBUG` lines with the level set to `debug` | present | byte-identical |
| `DEBUG` lines with the level unset | absent | absent |
| `WARNING` line | `WARN:` | `WARNING:` |
| application's own log format in effect | yes | yes |
| application's `DEBUG` suppressed as it asked | yes | yes |
| `logging` imported when nothing is emitted | no | no |

That one word is the whole diff in the output, on every interpreter.

Also run: the unit suite (37 tests), `go test` for all four cases of `TestSitecustomizePythonVersionCompatibility` including the new assertions, `gofmt`, `go vet`, and `python2.7 -m py_compile` on the script.

## Commits

1. `test(python)`: the diagnostics channel had no test for the severity contract, and none for the property that makes it safe. The container application now configures logging at INFO with its own format, so the suite asserts on every interpreter that the format survives and the application's DEBUG stays hidden. Passes before the change.
2. `refactor(python)`: the change itself.
3. `docs(python)`: neither the README nor the man page said where the agent's output goes, what the severity means, or that it never enters the application's logging.

## Notes for review

**`WARN` becomes `WARNING`.** That is the name `logging` gives the level, and using its names is the point of the change. Nothing breaks: the unit tests assert `assertIn("WARN", output)`, which matches `WARNING` as a substring, and the Go tests grep the message text, never the level token. Worth a second opinion though, because `WARN` is the OpenTelemetry log data model's severity text, so there is an argument for mapping the name back in the `Formatter`. I did not, because remapping the level name would be hand-rolling the representation we are delegating.

**The Node.js bundle now says something different.** `packaging/common/nodejs/register.js` writes `[opentelemetry-nodejs-autoinstrumentation] WARN:` through `process.stderr.write`. Keeping the two bundles consistent matters, but it belongs in a change that owns both, so it is not here.

**`_SilentStreamHandler` is nested inside `_get_logger`.** It has to be, since `logging` is not imported at module scope. It exists so a failed write stays silent, which is what `except Exception: pass` did: `Handler.handleError` would otherwise write a `--- Logging error ---` traceback to `sys.stderr`, the stream that just failed, and it swallows only `OSError` while doing it. Subclassing keeps this out of `logging.raiseExceptions`, which is global state the application owns.

**`from __future__ import print_function` is removed** because nothing prints any more. It was also a guard against someone writing `print(a, b)` and getting a tuple on 2.7. Happy to put it back if you would rather keep the guard.

**Accepted risk.** An application with its own `logging.py` on `PYTHONPATH` shadows the stdlib module and the lazy import gets theirs. Not a new class of exposure: `logging`, `subprocess`, `re`, and `threading` are all absent from a bare interpreter's `sys.modules`, so the existing `import subprocess` in `_validate_config_file` already has it. It is also an environment that breaks the application before it breaks us.

## Not in this PR

- Teaching `OTEL_INJECTOR_LOG_LEVEL` real levels (`info`, `warning`, `error`) and making it case-insensitive. It is a boolean wearing a level's name today, and real levels make it cheap, but it changes behavior, so it deserves its own change.
- `_print_cannot_auto_instrument_message` no longer prints. Renaming it touches every call site and would bury this diff.
