### PR TITLE
fix(python): deactivate when an unexpected error escapes import_distro()

### DIFF
--- a/packaging/common/python/README.md
+++ b/packaging/common/python/README.md
@@ -107,6 +107,12 @@ configuration file that `otel-config-check` accepts and the SDK's file configura
 rejects: the validator checks the YAML and `file_format`, while the SDK validates the whole
 document against its schema.
 
+Any unexpected error in the checks themselves self-deactivates as well, and reports the
+exception type and message. Deactivating means the site directory is removed from
+`sys.path` and from `PYTHONPATH`, and the injector's agent path prefix is cleared, so child
+processes do not retry a failed activation. The application is never prevented from
+starting by any of this.
+
 ## Supported libraries
 
 Instrumentation plug-ins are included for:

--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -382,4 +382,21 @@ def import_distro():
         _print_cannot_auto_instrument_message("dependency conflicts: {}".format(version_conflicts))
 
 
-import_distro()
+# Every guard above exists to leave the process in a known state, and an
+# exception escaping import_distro() is the one path that leaves it in the
+# state they prevent: the site still on PYTHONPATH and the injector prefix
+# still set, so every child process that execs an interpreter retries the same
+# failure, while site.execsitecustomize() reports a single line that does not
+# name this agent and carries no traceback unless PYTHONVERBOSE is set.
+# The reporting is itself guarded, because the step that failed can be the one
+# that reports.
+try:
+    import_distro()
+except Exception as unexpected_error:
+    try:
+        _self_deactivate(dirname(__file__))
+        _print_cannot_auto_instrument_message(
+            "unexpected error while deciding whether to auto-instrument: {}: {}".format(
+                type(unexpected_error).__name__, unexpected_error))
+    except Exception:
+        pass

--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -149,7 +149,11 @@ def _check_for_double_instrumentation(current_site):
     for dist in importlib.metadata.distributions():
         name = dist.metadata["Name"]
         if name is not None and name in double_instrumentation_check_packages:
-            offending_packages.append(str(dist._path))
+            # The operator reading the deactivation message has to find and
+            # remove this package, so name it with its version and its install
+            # directory. locate_file("") is abstract on Distribution, so that
+            # directory resolves for any finder, not just path-based installs.
+            offending_packages.append("{} {} ({})".format(name, dist.version, dist.locate_file("")))
     if offending_packages:
         _self_deactivate(current_site)
         _print_cannot_auto_instrument_message(

--- a/packaging/common/python/test_sitecustomize.py
+++ b/packaging/common/python/test_sitecustomize.py
@@ -209,6 +209,7 @@ class ImportDistroTests(unittest.TestCase):
         installed_distributions=None,
         sys_path_entry=None,
         initialize_side_effect=None,
+        distributions_side_effect=None,
     ):
         """Execute sitecustomize.py end to end.
 
@@ -220,6 +221,10 @@ class ImportDistroTests(unittest.TestCase):
 
         initialize_side_effect makes the mocked initialize() raise, which is
         how the SDK reports a failure it cannot recover from.
+
+        distributions_side_effect makes importlib.metadata.distributions raise,
+        which stands in for any failure inside import_distro() that has no
+        try block of its own.
 
         Returns (stderr output, auto_instrumentation mock, environment
         observed right after the run).
@@ -248,7 +253,8 @@ class ImportDistroTests(unittest.TestCase):
         with patch.dict(os.environ, env, clear=True), \
                 patch.object(sys, "path", list(sys.path) + [sys_path_entry or self.site_dir]), \
                 patch("os.path.dirname", side_effect=fake_dirname), \
-                patch("importlib.metadata.distributions", return_value=installed_distributions or []), \
+                patch("importlib.metadata.distributions", return_value=installed_distributions or [],
+                      side_effect=distributions_side_effect), \
                 patch("importlib.metadata.distribution", return_value=distribution), \
                 patch.dict(sys.modules, {
                     "opentelemetry": MagicMock(),
@@ -445,6 +451,21 @@ class ImportDistroTests(unittest.TestCase):
             installed_distributions=[dist],
         )
         self._assert_activated(auto_instrumentation, observed_env)
+
+    def test_unexpected_error_deactivates_with_a_warning(self):
+        # Only four steps inside import_distro() have a try block of their
+        # own. An exception from any other step escaped into
+        # site.execsitecustomize(), which reports one line that does not name
+        # this agent and leaves the site on PYTHONPATH for every child process
+        # to retry. The outer guard turns that into an ordinary deactivation.
+        output, auto_instrumentation, observed_env = self._exec_sitecustomize(
+            extra_env={"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"},
+            all_dependencies="foo==1.0.0\n",
+            distributions_side_effect=RuntimeError("metadata backend exploded"),
+        )
+        self._assert_deactivated(auto_instrumentation, observed_env)
+        self.assertIn("unexpected error while deciding whether to auto-instrument", output)
+        self.assertIn("RuntimeError: metadata backend exploded", output)
 
     def test_trailing_slash_pythonpath_entry_does_not_crash(self):
         # The sys.path entry can differ textually from dirname(__file__)

--- a/packaging/common/python/test_sitecustomize.py
+++ b/packaging/common/python/test_sitecustomize.py
@@ -432,7 +432,8 @@ class ImportDistroTests(unittest.TestCase):
     def test_deactivates_on_double_instrumentation(self):
         dist = MagicMock()
         dist.metadata = {"Name": "opentelemetry-sdk"}
-        dist._path = "/app/site-packages/opentelemetry_sdk-1.20.0.dist-info"
+        dist.version = "1.20.0"
+        dist.locate_file.return_value = "/app/site-packages"
         output, auto_instrumentation, observed_env = self._exec_sitecustomize(
             extra_env={"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"},
             all_dependencies="foo==1.0.0\n",
@@ -440,7 +441,29 @@ class ImportDistroTests(unittest.TestCase):
         )
         self._assert_deactivated(auto_instrumentation, observed_env)
         self.assertIn("already instrumented", output)
-        self.assertIn("opentelemetry_sdk-1.20.0.dist-info", output)
+        self.assertIn("opentelemetry-sdk 1.20.0 (/app/site-packages)", output)
+
+    def test_deactivates_on_a_distribution_from_a_non_path_finder(self):
+        # A distribution implementing only the public Distribution interface,
+        # as any finder other than the path-based one produces, must still be
+        # detected and named rather than raising. A real object is used here,
+        # not a MagicMock, because a MagicMock answers to every attribute and
+        # would hide exactly the bug this covers.
+        class DistributionFromNonPathFinder(object):
+            metadata = {"Name": "opentelemetry-sdk"}
+            version = "1.20.0"
+
+            def locate_file(self, path):
+                return "/app/site-packages"
+
+        output, auto_instrumentation, observed_env = self._exec_sitecustomize(
+            extra_env={"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"},
+            all_dependencies="foo==1.0.0\n",
+            installed_distributions=[DistributionFromNonPathFinder()],
+        )
+        self._assert_deactivated(auto_instrumentation, observed_env)
+        self.assertIn("already instrumented", output)
+        self.assertIn("opentelemetry-sdk 1.20.0 (/app/site-packages)", output)
 
     def test_unrelated_installed_distribution_does_not_deactivate(self):
         dist = MagicMock()


### PR DESCRIPTION
Fixes #98.

`import_distro()` was called with nothing around it, so an exception from any step that has no `try` block of its own escaped into `site.execsitecustomize()`. The process then ended up in the one state every guard in the file exists to prevent, and #93 had already established that this state is worth preventing. #94 closed one door into it; this closes the frame.

## The failure

Reproduced with the packaged script, unmodified, on `python:3.13-slim`. A `.pth` file in `site-packages` replaces `importlib.metadata.distributions` with one returning a `Distribution` that has `metadata["Name"] == "opentelemetry-sdk"` and no private `_path`, which is what line 111 read. The `.pth` is only a way to get in front of `sitecustomize.py`, since `site` processes `site-packages/*.pth` before `execsitecustomize()`.

| | before | after |
|---|---|---|
| site in `PYTHONPATH` | still present | removed |
| `PYTHON_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX` | still set | cleared |
| `[opentelemetry-python-autoinstrumentation]` lines | 0 | 1 |
| child process repeats the failure | yes | no |
| what the operator sees | `Error in sitecustomize; set PYTHONVERBOSE for traceback:` | the guard message, naming the cause |
| application exit code | 0 | 0 |

Three things made it worth fixing above the other findings in this file:

1. **The report does not name this agent.** CPython prints one line, without the `[opentelemetry-python-autoinstrumentation]` prefix and without a traceback unless `PYTHONVERBOSE` is set. This repository's own container assertions grep for that prefix, so they would not catch it either.
2. **Every child process retries.** `_self_deactivate` exists precisely so children do not, and it never ran. On gunicorn or celery that multiplies by the worker count.
3. **`sys.path` was left inconsistent.** The failure lands between the removal on line 291 and the re-append on line 299, so the parent had neither instrumentation nor the bundle importable. #93's failure at least left the bundle on `sys.path`.

The application was never harmed and always exited 0, which is what let this go unnoticed.

## Commits

1. `fix(python)`: the outer guard. Its own reporting is guarded too, because the step that failed can be the step that reports. The new unit test fails without it, with the `RuntimeError` propagating out of `exec_module`.
2. `fix(python)`: replace the private `dist._path` with `locate_file("")`, removing the most reachable trigger. `locate_file` is abstract on `Distribution`, so every implementation has it, while `_path` exists only on `PathDistribution`. The message gains the version: `opentelemetry-sdk 1.20.0 (/app/site-packages)`.
3. `docs(python)`: the safety-guard list stopped at the four anticipated checks, and never said what deactivating actually does.

The two fixes are complementary, and the second commit's test shows why both are wanted. Without the `locate_file` change, the guard from commit 1 catches the `AttributeError` and deactivates with "unexpected error" rather than correctly reporting the double instrumentation. The guard makes the failure graceful; the `locate_file` change makes it correct.

## Verified

- The unit suite, 32 tests.
- `TestSitecustomizePythonVersionCompatibility`, all four interpreters.
- `python2.7 -m py_compile` on the script, so the parse contract on line 11 holds.
- The reproduction above, before and after, plus a third run proving the `locate_file` path reports the offending distribution correctly rather than merely failing gracefully.

## Notes for review

**The inner guard is deliberate and untested.** Reaching it needs `_self_deactivate` or the diagnostics channel itself to fail, which the unit harness cannot arrange without contortions. I would rather have four lines of unreachable insurance in a file that runs in every Python process on the host than a handler that can raise from inside an exception handler.

**Independent of #96 and #97.** Different lines, no dependency, and either order merges. The only overlap is that both PRs insert into `test_sitecustomize.py`, at different anchors, so a conflict there would resolve by keeping both.

**One interaction worth knowing about.** #97 makes the diagnostics import `logging` lazily, and the two module-level `_log_debug` calls near the top of the file sit outside this guard. If both land, moving those two calls inside `import_distro()` would put them under it, which is a one-line follow-up rather than something to settle here.

**This does not fix the other unguarded call sites, by design.** `importlib.metadata.distributions()` on line 108, `from packaging.requirements import Requirement` on lines 143-144 which resolves against an application-supplied `packaging`, and `import subprocess` on line 205 which is shadowable from `PYTHONPATH`. The guard covers all of them, and each is a separate question about whether it should also be handled at the source.
