### PR TITLE
fix(python): resolve the OTLP protocol per signal in sitecustomize.py

### DIFF
--- a/packaging/common/python/README.md
+++ b/packaging/common/python/README.md
@@ -44,10 +44,14 @@ exporters (they emit protobuf only).
 
 - `OTEL_SERVICE_NAME`: Service name for telemetry (required)
 - `OTEL_EXPORTER_OTLP_ENDPOINT`: OTLP endpoint (default: http://localhost:4318 for http/protobuf, http://localhost:4317 for grpc)
-- `OTEL_EXPORTER_OTLP_PROTOCOL`: `grpc` or `http/protobuf` (unset defaults to `grpc`)
-- `OTEL_TRACES_EXPORTER`: Traces exporter (default follows the protocol: `otlp_proto_grpc` or `otlp_proto_http`)
-- `OTEL_METRICS_EXPORTER`: Metrics exporter (default follows the protocol)
-- `OTEL_LOGS_EXPORTER`: Logs exporter (default follows the protocol)
+- `OTEL_EXPORTER_OTLP_PROTOCOL`: `grpc` or `http/protobuf` (unset, empty, or whitespace defaults to `grpc`)
+- `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`, `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL`,
+  `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL`: the same values. Each takes precedence over the generic
+  variable for its own signal, so signals may use different protocols. `http/json` in any of
+  them self-deactivates, naming the variable that carried it.
+- `OTEL_TRACES_EXPORTER`: Traces exporter (default follows that signal's protocol: `otlp_proto_grpc` or `otlp_proto_http`)
+- `OTEL_METRICS_EXPORTER`: Metrics exporter (default follows that signal's protocol)
+- `OTEL_LOGS_EXPORTER`: Logs exporter (default follows that signal's protocol)
 - `OTEL_PYTHON_DISABLED_INSTRUMENTATIONS`: Comma-separated list of instrumentations to disable
 - `OTEL_INJECTOR_LOG_LEVEL`: Set to `debug` for verbose sitecustomize.py logging
 
@@ -87,9 +91,10 @@ export OTEL_CONFIG_FILE=/etc/opentelemetry/python/otel-config.yaml
 `sitecustomize.py` performs the following checks at startup before activating instrumentation:
 
 1. **Python version**: Requires Python ≥ 3.10. Older versions are skipped gracefully.
-2. **OTLP protocol / configuration file**: Without `OTEL_CONFIG_FILE`, accepts
-   `OTEL_EXPORTER_OTLP_PROTOCOL` of `grpc` (the default when unset) or `http/protobuf`;
-   `http/json` self-deactivates. With `OTEL_CONFIG_FILE` set,
+2. **OTLP protocol / configuration file**: Without `OTEL_CONFIG_FILE`, resolves the protocol
+   per signal (`OTEL_EXPORTER_OTLP_{TRACES,METRICS,LOGS}_PROTOCOL` taking precedence over
+   `OTEL_EXPORTER_OTLP_PROTOCOL`, as the SDK does) and accepts `grpc` (the default when unset)
+   or `http/protobuf`; `http/json` self-deactivates. With `OTEL_CONFIG_FILE` set,
    the SDK ignores the `OTEL_*` exporter variables, so instead the bundled
    `otel-config-check` utility validates the configuration file (readable, valid YAML,
    `file_format: "1.0"`; both `otlp_http` and `otlp_grpc` exporters are accepted).

--- a/packaging/common/python/opentelemetry-python.8.tmpl
+++ b/packaging/common/python/opentelemetry-python.8.tmpl
@@ -56,13 +56,19 @@ Set the OTLP exporter endpoint (e.g., http://localhost:4318).
 .B OTEL_EXPORTER_OTLP_PROTOCOL
 Set to
 .B grpc
-(the default when unset) or
+(the default when unset, empty, or whitespace) or
 .B http/protobuf
 (http/json is not supported by this package). Ignored when
 .B OTEL_CONFIG_FILE
 is set; the configuration file is then validated by the bundled
 .B otel-config-check
 utility instead.
+.TP
+.B OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, OTEL_EXPORTER_OTLP_METRICS_PROTOCOL, OTEL_EXPORTER_OTLP_LOGS_PROTOCOL
+The same values, each taking precedence over
+.B OTEL_EXPORTER_OTLP_PROTOCOL
+for its own signal, so signals may use different protocols. An unsupported value in any of
+them self-deactivates and names the variable that carried it.
 .TP
 .B OTEL_TRACES_EXPORTER
 Set the traces exporter (default follows the protocol: otlp_proto_grpc or otlp_proto_http).

--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -343,6 +343,30 @@ def _render_version_conflicts(version_conflicts):
     return "; ".join(descriptions)
 
 
+otlp_signals = ["TRACES", "METRICS", "LOGS"]
+
+
+def _otlp_protocol_for_signal(signal):
+    # The signal-specific variable takes precedence over the generic one, per
+    # the OTLP specification, and opentelemetry.sdk._configuration implements
+    # exactly that precedence when it resolves an exporter. A guard that reads
+    # only the generic variable therefore validates a value the SDK may never
+    # read and misses the one it does.
+    #
+    # A blank (empty or only-whitespaces) value counts as unset here too, so a
+    # blank signal-specific variable lets the generic one through instead of
+    # shadowing it with nothing. The value is returned stripped so a rejection
+    # message quotes it the way _exporter_for_protocol read it.
+    #
+    # Returns (variable name, protocol), so a rejection can name the variable
+    # that actually carried the value. Both are None when no variable sets one.
+    for name in ("OTEL_EXPORTER_OTLP_{}_PROTOCOL".format(signal), "OTEL_EXPORTER_OTLP_PROTOCOL"):
+        value = environ.get(name)
+        if value is not None and value.strip():
+            return name, value.strip()
+    return None, None
+
+
 def _exporter_for_protocol(otlp_protocol):
     # This package bundles pure-Python OTLP exporters for both gRPC and
     # HTTP/protobuf (the gRPC one transports over the stdlib-only _pygrpc
@@ -372,10 +396,11 @@ def import_distro():
         return
     _log_debug("found eligible Python version: {}".format(version_info))
 
-    # Exporter selected from OTEL_EXPORTER_OTLP_PROTOCOL below (env-var mode).
-    # Under OTEL_CONFIG_FILE the configuration file drives exporter selection
-    # and OTEL_*_EXPORTER is ignored, so this default is inert in that mode.
-    default_exporter = "otlp_proto_grpc"
+    # Exporter selected per signal from the OTLP protocol variables below
+    # (env-var mode). Under OTEL_CONFIG_FILE the configuration file drives
+    # exporter selection and OTEL_*_EXPORTER is ignored, so this stays empty
+    # in that mode.
+    exporter_by_signal = {}
     config_file = environ.get("OTEL_CONFIG_FILE")
     if config_file:
         # With OTEL_CONFIG_FILE in effect the SDK ignores the OTEL_* exporter
@@ -391,18 +416,24 @@ def import_distro():
                     config_file, validation_error))
             return
     else:
-        _log_debug("checking OTEL_EXPORTER_OTLP_PROTOCOL")
+        _log_debug("checking the OTLP protocol of each signal")
 
-        otlp_protocol = environ.get("OTEL_EXPORTER_OTLP_PROTOCOL")
-        default_exporter = _exporter_for_protocol(otlp_protocol)
-        if default_exporter is None:
-            _self_deactivate(current_site)
-            _log_cannot_auto_instrument_warning(
-                "OTEL_EXPORTER_OTLP_PROTOCOL={} is not supported. "
-                "This package supports grpc and http/protobuf.".format(otlp_protocol)
-            )
-            return
-        _log_debug("found eligible OTEL_EXPORTER_OTLP_PROTOCOL value: {}".format(otlp_protocol))
+        # Resolved per signal, because the SDK resolves it per signal: an
+        # exporter chosen from the generic variable alone would silently
+        # discard OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf and export
+        # over grpc instead.
+        for signal in otlp_signals:
+            variable, otlp_protocol = _otlp_protocol_for_signal(signal)
+            exporter = _exporter_for_protocol(otlp_protocol)
+            if exporter is None:
+                _self_deactivate(current_site)
+                _log_cannot_auto_instrument_warning(
+                    "{}={} is not supported. "
+                    "This package supports grpc and http/protobuf.".format(variable, otlp_protocol)
+                )
+                return
+            exporter_by_signal[signal] = exporter
+            _log_debug("{} resolves to the {} exporter".format(signal, exporter))
 
     _log_debug("checking for double instrumentation")
 
@@ -438,14 +469,16 @@ def import_distro():
 
     if not version_conflicts:
         if not config_file:
-            # Select the bundled pure-Python OTLP exporter matching the protocol
-            # (otlp_proto_grpc or otlp_proto_http), both registered as drop-in
-            # replacements under the standard entry points. No-ops if the user
-            # already set these. Skipped under OTEL_CONFIG_FILE, where the
-            # configuration file drives exporter selection and these are ignored.
-            environ.setdefault("OTEL_TRACES_EXPORTER", default_exporter)
-            environ.setdefault("OTEL_METRICS_EXPORTER", default_exporter)
-            environ.setdefault("OTEL_LOGS_EXPORTER", default_exporter)
+            # Select the bundled pure-Python OTLP exporter matching each
+            # signal's protocol (otlp_proto_grpc or otlp_proto_http), both
+            # registered as drop-in replacements under the standard entry
+            # points. Per signal, because the protocol is resolved per signal:
+            # a deployment can ask for http/protobuf traces and grpc metrics.
+            # No-ops if the user already set these. Skipped under
+            # OTEL_CONFIG_FILE, where the configuration file drives exporter
+            # selection and these are ignored.
+            for signal in otlp_signals:
+                environ.setdefault("OTEL_{}_EXPORTER".format(signal), exporter_by_signal[signal])
         try:
             _log_debug("importing and initializing the Python auto-instrumentation now")
             from opentelemetry.instrumentation import auto_instrumentation

--- a/packaging/common/python/test_sitecustomize.py
+++ b/packaging/common/python/test_sitecustomize.py
@@ -589,6 +589,45 @@ class ImportDistroTests(unittest.TestCase):
         )
         self.assertEqual("", output)
 
+    def test_signal_specific_protocol_selects_that_signal_exporter(self):
+        # The signal-specific variable takes precedence over the generic one,
+        # per the OTLP specification and per the SDK's own resolution. Reading
+        # only the generic variable meant this request was silently discarded
+        # and traces went out over grpc.
+        _, auto_instrumentation, observed_env = self._exec_sitecustomize(
+            extra_env={"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "http/protobuf"},
+            all_dependencies="foo==1.0.0\n",
+        )
+        auto_instrumentation.initialize.assert_called_once_with(swallow_exceptions=False)
+        self.assertEqual("otlp_proto_http", observed_env["OTEL_TRACES_EXPORTER"])
+        self.assertEqual("otlp_proto_grpc", observed_env["OTEL_METRICS_EXPORTER"])
+        self.assertEqual("otlp_proto_grpc", observed_env["OTEL_LOGS_EXPORTER"])
+
+    def test_signal_specific_protocol_overrides_the_generic_one(self):
+        _, auto_instrumentation, observed_env = self._exec_sitecustomize(
+            extra_env={
+                "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
+                "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL": "http/protobuf",
+            },
+            all_dependencies="foo==1.0.0\n",
+        )
+        auto_instrumentation.initialize.assert_called_once_with(swallow_exceptions=False)
+        self.assertEqual("otlp_proto_grpc", observed_env["OTEL_TRACES_EXPORTER"])
+        self.assertEqual("otlp_proto_grpc", observed_env["OTEL_METRICS_EXPORTER"])
+        self.assertEqual("otlp_proto_http", observed_env["OTEL_LOGS_EXPORTER"])
+
+    def test_deactivates_when_a_signal_specific_protocol_is_http_json(self):
+        # http/json in the signal-specific variable used to pass the guard
+        # untouched and activate over grpc, which is the one value the guard
+        # exists to reject.
+        output, auto_instrumentation, observed_env = self._exec_sitecustomize(
+            extra_env={"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": "http/json"},
+            all_dependencies="foo==1.0.0\n",
+        )
+        self._assert_deactivated(auto_instrumentation, observed_env)
+        self.assertIn("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=http/json is not supported", output)
+        self.assertIn("supports grpc and http/protobuf", output)
+
     def test_deactivates_when_protocol_is_http_json(self):
         # The bundled pyproto exporter emits protobuf only; http/json must be
         # rejected until the exporter chain supports JSON encoding.


### PR DESCRIPTION
Fixes #100.

The protocol guard read only the generic `OTEL_EXPORTER_OTLP_PROTOCOL`, and one protocol chose the exporter for all three signals. The OTLP specification gives `OTEL_EXPORTER_OTLP_{SIGNAL}_PROTOCOL` precedence over the generic variable, and `opentelemetry-sdk` implements that precedence, so the guard was validating a value the SDK may never read and missing the one it does.

## Observed, before and after

Packaged script on `python:3.13-slim`, with a stub entry point making the activation observable.

| case | environment | before | after |
|---|---|---|---|
| A | `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` | `http, http, http` | unchanged |
| B | `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf` | `grpc, grpc, grpc` | **`http, grpc, grpc`** |
| C | `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/json` | activated over grpc | **deactivates, naming that variable** |
| D | `OTEL_EXPORTER_OTLP_PROTOCOL=` (set, empty) | **agent deactivated** | activates over grpc |
| E | generic `grpc` + `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL=http/protobuf` | `grpc, grpc, grpc` | **`grpc, grpc, http`** |

Both of the silent cases mattered more than the loud one:

**B** is wrong telemetry, not absent telemetry. An operator who sets `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf` alongside an HTTP `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` got a gRPC exporter aimed at it, so export failed at runtime with nothing but the exporter's own retry logging to show for it. The SDK does emit a "conflicting values" warning here, but only because `sitecustomize.py` had already pinned a concrete exporter name, and that `logging` record can reach nobody, on an application that routes its own logging elsewhere.

**C** means `http/json` was only rejected when spelled one particular way. It is the one value the guard exists to reject, the bundled exporters cannot emit it, and there was no warning at all: `http/json` is absent from the SDK's protocol table, so its conflict lookup returns `None` and the warning is skipped.

## The SDK was already right

`opentelemetry/sdk/_configuration/__init__.py` at the pinned 1.44.0 resolves per signal, strips whitespace, treats an empty value as unset, and raises on an unsupported protocol. Every behaviour the guard was missing. This PR makes `sitecustomize.py` resolve the protocol by the same rules, once per signal, and uses that single resolution for both the guard and the exporter selection, because the two have to agree.

The guard stays rather than deferring to the SDK's `RuntimeError`, for the reason argued in #93: deactivating before any instrumentation plug-in has patched the process is a clean rollback, and failing during initialization is not.

## Commits

1. `fix(python)`: an empty or whitespace-only protocol value counts as unset. The narrow defect on its own, since `value: ""` in a Kubernetes manifest disabling all instrumentation is worth reading as a single change.
2. `fix(python)`: resolve per signal, with signal-specific precedence, and select each signal's exporter from its own protocol. A rejection now names the variable that carried the value instead of always naming the generic one.
3. `docs(python)`: the README and the man page named only the generic variable. That gap is how the blind spot stayed invisible, since the documentation described exactly the subset of the specification the code implemented.

Each fix commit's tests fail without it: two for the first, three for the second.

## Verified

- The unit suite, 35 tests.
- `TestSitecustomizePythonVersionCompatibility`, all four interpreters.
- `python2.7 -m py_compile`, so the parse contract on line 11 holds.
- The five cases above on `python:3.13-slim`, before and after.
- The man page renders.

## Notes for review

**The existing contract is intact.** `OTEL_EXPORTER_OTLP_PROTOCOL=http/json is not supported` is still exactly what an operator sees when the generic variable carries the bad value, which is what `sitecustomize_test.go:49` and `test_sitecustomize.py` assert. No Go assertion depends on the concrete `OTEL_*_EXPORTER` values for Python.

**`otlp_signals` is a module-level list** rather than a literal repeated three times, so the guard and the exporter selection cannot drift apart. It sits next to the two existing module-level package lists.

**An alternative I did not take.** `sitecustomize.py` could set `OTEL_*_EXPORTER=otlp` and let the SDK resolve the entry point itself, which is less code and delegates to the component that already does this correctly. I kept the concrete names because they are what pins the bundled pure-Python exporters, which is the point of the current comment on those lines, and because changing what the SDK sees deserves its own change rather than riding along with a bug fix. Happy to do it as a follow-up if you would rather delegate.

**Independent of #96, #97, #98, and #99.** Different lines. The only overlap is that these PRs each insert into `test_sitecustomize.py`, at different anchors, so any conflict resolves by keeping both sides.

