### PR TITLE
fix(python): detect every package this bundle vendors as double instrumentation

### DIFF
--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -20,6 +20,13 @@ from os.path import dirname, isfile, join, normpath
 import sys
 from sys import path, version, version_info, stderr
 
+# Distributions whose presence in the application means it is already
+# instrumented. Activating on top of one of them would put a second copy of the
+# same modules and entry points in the process, which the distributions cannot
+# survive: they ship conflicting files. Every distribution this bundle installs
+# that owns a public opentelemetry.* module path belongs here, which includes
+# the whole vendored pyproto chain in requirements.txt. Kept sorted so a new
+# requirements.txt entry is easy to check against this list.
 double_instrumentation_check_packages = [
     "opentelemetry-distro",
     "opentelemetry-exporter-otlp",
@@ -30,8 +37,8 @@ double_instrumentation_check_packages = [
     "opentelemetry-exporter-otlp-pyproto-http",
     "opentelemetry-exporter-prometheus",
     "opentelemetry-instrumentation",
-    "opentelemetry-sdk",
     "opentelemetry-proto",
+    "opentelemetry-sdk",
 ]
 
 # Packages exempt from deactivation on version conflicts: general-purpose

--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -34,10 +34,12 @@ double_instrumentation_check_packages = [
     "opentelemetry-exporter-otlp-proto-grpc",
     "opentelemetry-exporter-otlp-proto-http",
     "opentelemetry-exporter-otlp-pyproto-common",
+    "opentelemetry-exporter-otlp-pyproto-grpc",
     "opentelemetry-exporter-otlp-pyproto-http",
     "opentelemetry-exporter-prometheus",
     "opentelemetry-instrumentation",
     "opentelemetry-proto",
+    "opentelemetry-pyproto",
     "opentelemetry-sdk",
 ]
 

--- a/packaging/common/python/test_sitecustomize.py
+++ b/packaging/common/python/test_sitecustomize.py
@@ -777,6 +777,35 @@ class ImportDistroTests(unittest.TestCase):
         )
         self._assert_activated(auto_instrumentation, observed_env)
 
+    def test_deactivates_on_the_vendored_grpc_exporter(self):
+        # The bundle vendors this exporter, so an application carrying it means
+        # a second copy of the same distribution is about to enter the process.
+        dist = MagicMock()
+        dist.metadata = {"Name": "opentelemetry-exporter-otlp-pyproto-grpc"}
+        dist._path = "/app/site-packages/opentelemetry_exporter_otlp_pyproto_grpc-1.44.0.dist-info"
+        output, auto_instrumentation, observed_env = self._exec_sitecustomize(
+            extra_env={"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"},
+            all_dependencies="foo==1.0.0\n",
+            installed_distributions=[dist],
+        )
+        self._assert_deactivated(auto_instrumentation, observed_env)
+        self.assertIn("already instrumented", output)
+
+    def test_deactivates_on_the_vendored_pyproto_encoder(self):
+        # opentelemetry-pyproto owns the public opentelemetry.proto module path,
+        # the same one opentelemetry-proto owns, so it is double instrumentation
+        # for the same reason its upstream counterpart is.
+        dist = MagicMock()
+        dist.metadata = {"Name": "opentelemetry-pyproto"}
+        dist._path = "/app/site-packages/opentelemetry_pyproto-1.44.0.dist-info"
+        output, auto_instrumentation, observed_env = self._exec_sitecustomize(
+            extra_env={"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"},
+            all_dependencies="foo==1.0.0\n",
+            installed_distributions=[dist],
+        )
+        self._assert_deactivated(auto_instrumentation, observed_env)
+        self.assertIn("already instrumented", output)
+
     def test_unrelated_installed_distribution_does_not_deactivate(self):
         dist = MagicMock()
         dist.metadata = {"Name": "flask"}

--- a/packaging/common/python/test_sitecustomize.py
+++ b/packaging/common/python/test_sitecustomize.py
@@ -917,6 +917,41 @@ class ImportDistroTests(unittest.TestCase):
         self._assert_activated(auto_instrumentation, observed_env)
 
 
+class DoubleInstrumentationPackageListTests(unittest.TestCase):
+    """The double-instrumentation list against the bundle it has to describe.
+
+    The list is maintained by hand, so nothing but a test keeps it in step with
+    requirements.txt. It fell behind once already: the vendored gRPC exporter
+    and opentelemetry-pyproto were installed by the bundle without being added
+    here, and an application carrying either was not recognised as instrumented.
+    """
+
+    def setUp(self):
+        self.module, self.stderr = _load_benign()
+
+    def test_every_vendored_package_is_checked(self):
+        # A vendored package is one this bundle installs from source, so an
+        # application carrying it means a second copy of the same distribution.
+        with open(os.path.join(TEST_DIR, "requirements.txt")) as f:
+            vendored = [
+                os.path.basename(line.strip())
+                for line in f
+                if line.strip().startswith("./vendor/")
+            ]
+        self.assertTrue(vendored, "no vendored requirements found to check against")
+        for name in vendored:
+            self.assertIn(name, self.module.double_instrumentation_check_packages)
+
+    def test_the_list_is_sorted(self):
+        # Sorted so a new requirements.txt entry can be checked against it by eye.
+        packages = self.module.double_instrumentation_check_packages
+        self.assertEqual(sorted(packages), packages)
+
+    def test_the_list_has_no_duplicates(self):
+        packages = self.module.double_instrumentation_check_packages
+        self.assertEqual(len(set(packages)), len(packages))
+
+
 class LoggingTests(unittest.TestCase):
     """The contract of the diagnostics channel.
 


### PR DESCRIPTION
Fixes #102.

`double_instrumentation_check_packages` named two of the four packages this bundle vendors. An application already carrying either of the other two was not recognised as instrumented, so the agent activated on top of it and the process ended up with two copies of the same distribution claiming the same module paths and the same entry points.

## Observed, before and after

`python:3.12-slim`, bundle-shaped layout: `sitecustomize.py` and `all-dependencies.txt` in `/agent/glibc`, an application site at `/appsite`, `PYTHONPATH=/agent/glibc:/appsite`. All four vendored distributions present in the agent site throughout. One distribution installed into the application site per run.

| application site carries | before | after |
|---|---|---|
| nothing (agent site only) | not detected | unchanged |
| `opentelemetry-exporter-otlp-pyproto-http` | detected | unchanged |
| `opentelemetry-exporter-otlp-pyproto-common` | detected | unchanged |
| `opentelemetry-exporter-otlp-pyproto-grpc` | **not detected** | detected |
| `opentelemetry-pyproto` | **not detected** | detected |
| `flask` | not detected | unchanged |

The first and last rows are the ones that matter for regression risk. Adding names to this list cannot make the agent detect itself, because the check runs with the agent's own site removed from `sys.path` for exactly that reason, and the same exposure already existed for the two names that were in the list. Both confirmed above rather than assumed.

## Why these two

`requirements.txt:38-41` installs four packages from `vendor/`. The list named `-pyproto-http` and `-pyproto-common` but not `-pyproto-grpc` nor `opentelemetry-pyproto`. It did name `opentelemetry-proto`, which is the package `opentelemetry-pyproto` is the drop-in replacement for and whose public `opentelemetry.proto` module path it owns, so the guard rejected the upstream spelling of a dependency while accepting the bundle's own.

`requirements.txt` already states why two copies are not survivable:

> the real proto exporters and their google-protobuf C extension must NOT be bundled — the distributions ship conflicting files.

The gRPC exporter was added to the vendor set after the list was written. That is the whole story: a hand-maintained list with nothing checking it against the thing it describes.

## Commits

1. `refactor(python)`: sort the list and add a comment saying what belongs in it. `opentelemetry-proto` sat out of alphabetical order at the end, and there was no statement of the rule, which is part of why the drift went unnoticed. No behaviour change, kept separate so the next commit's diff is two added lines.
2. `fix(python)`: add the two names, with an end-to-end test each.
3. `test(python)`: assert that every `./vendor/` requirement appears in the list, and that the list stays sorted and duplicate-free. This is the commit that stops it happening again.

All three of the new assertions fail on the tree before commit 2, so the drift guard would have caught the gap at the moment the gRPC exporter was vendored.

## Verified

- The unit suite, 43 tests.
- `TestSitecustomizePythonVersionCompatibility`, all four interpreters.
- `python2.7 -m py_compile`, so the parse contract on line 11 holds.
- The six cases in the table above, before and after, on a real bundle-shaped layout.

## Notes for review

**No documentation change.** The README and the man page describe the double-instrumentation check by what it does, not by which distributions it names, so neither goes stale. Say the word if you would rather the list were documented.

**The drift guard reads `requirements.txt` directly** rather than duplicating the vendored names into the test. A test with its own copy of the list would have needed the same manual update that was missed in the first place.

**Adjacent, filed separately.** `_check_for_double_instrumentation` compares the raw metadata `Name`, so matching is case- and separator-sensitive and does not follow PEP 503 normalisation: `opentelemetry_sdk` and `OpenTelemetry-SDK` both evade the guard. Same function, different defect, so it gets its own change.

**Independent of #99 and #101.** #99 touches the body of `_check_for_double_instrumentation` (`dist._path` to `locate_file`) while this touches only the list above it. Both insert into `test_sitecustomize.py` at different anchors, so any conflict resolves by keeping both sides.
