### PR TITLE
fix(python): compare package names by their PEP 503 normalized form

### DIFF
--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -143,16 +143,33 @@ def _self_deactivate(current_site):
     path[:] = [entry for entry in path if os.path.normpath(entry) != normalized_site]
 
 
+def _normalized_package_name(name):
+    # PEP 503: runs of "-", "_" and "." collapse to a single "-", lowercased.
+    # importlib.metadata normalizes the name a distribution is looked up by, but
+    # distributions() reports the Name each package declared, verbatim, and
+    # non-canonical ones are ordinary (PyYAML, typing_extensions, ruamel.yaml).
+    # So a comparison against one of the canonical lists above has to normalize.
+    #
+    # re is imported here rather than at module scope: the injector prepends this
+    # file to every Python process on the host, and re is not loaded at that
+    # point on any supported interpreter. Both callers import importlib.metadata,
+    # which pulls in re itself, so by the time this runs the import is free.
+    import re
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
 def _check_for_double_instrumentation(current_site):
     import importlib.metadata
     offending_packages = []
     for dist in importlib.metadata.distributions():
         name = dist.metadata["Name"]
-        if name is not None and name in double_instrumentation_check_packages:
+        if name is not None and _normalized_package_name(name) in double_instrumentation_check_packages:
             # The operator reading the deactivation message has to find and
             # remove this package, so name it with its version and its install
             # directory. locate_file("") is abstract on Distribution, so that
             # directory resolves for any finder, not just path-based installs.
+            # Reported under the name the package declared, which is the one
+            # they will see in pip list, not the normalized one matched above.
             offending_packages.append("{} {} ({})".format(name, dist.version, dist.locate_file("")))
     if offending_packages:
         _self_deactivate(current_site)

--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -244,7 +244,7 @@ def _check_dependency_version_conflict(req_string, version_conflicts):
 
     _log_debug("installed_version: {}".format(installed_version))
     if req.specifier and installed_version not in req.specifier:
-        if req.name.lower() in version_conflict_exempt_packages:
+        if _normalized_package_name(req.name) in version_conflict_exempt_packages:
             _log_warn(
                 'the installed version {} of package "{}" differs from the bundled requirement {}; '
                 "continuing anyway (the installed version takes precedence)".format(

--- a/packaging/common/python/test_sitecustomize.py
+++ b/packaging/common/python/test_sitecustomize.py
@@ -111,6 +111,29 @@ class NormalizedPackageNameTests(unittest.TestCase):
             self.module._normalized_package_name("opentelemetry-sdk-extras"))
 
 
+class PackageListCanonicalFormTests(unittest.TestCase):
+    """Both hardcoded lists are searched with a normalized name.
+
+    Only the incoming name is normalized, which is the cheap direction: it
+    happens once per candidate instead of once per list entry per candidate.
+    That makes it an invariant that the lists themselves are written in
+    normalized form, because an entry that is not can never be matched.
+    """
+
+    def setUp(self):
+        self.module, self.stderr = _load_benign()
+
+    def test_double_instrumentation_list_is_written_normalized(self):
+        for name in self.module.double_instrumentation_check_packages:
+            with self.subTest(name=name):
+                self.assertEqual(name, self.module._normalized_package_name(name))
+
+    def test_version_conflict_exempt_list_is_written_normalized(self):
+        for name in self.module.version_conflict_exempt_packages:
+            with self.subTest(name=name):
+                self.assertEqual(name, self.module._normalized_package_name(name))
+
+
 class CheckDependencyVersionConflictTests(unittest.TestCase):
     """Fine-grained tests for _check_dependency_version_conflict."""
 

--- a/packaging/common/python/test_sitecustomize.py
+++ b/packaging/common/python/test_sitecustomize.py
@@ -214,6 +214,30 @@ class CheckDependencyVersionConflictTests(unittest.TestCase):
         self.assertEqual({}, self.conflicts)
         self.assertIn("continuing anyway", self.stderr.getvalue())
 
+    def test_exemption_holds_whatever_case_the_requirement_uses(self):
+        # The exempt list is matched on the normalized name, so every casing of
+        # PyYAML is exempt. Neither exempt entry contains a separator, so the
+        # separator half of the rule has nothing to do at this call site; it is
+        # matched here the same way as in the double-instrumentation guard so
+        # the two cannot drift apart again.
+        for spelling in ("PyYAML", "pyyaml", "PYYAML", "PyYaml"):
+            with self.subTest(spelling=spelling):
+                self.conflicts = {}
+                self.stderr.truncate(0)
+                self.stderr.seek(0)
+                self._check(spelling + "==6.0.3", installed_version="6.0")
+                self.assertEqual({}, self.conflicts)
+                self.assertIn("continuing anyway", self.stderr.getvalue())
+
+    def test_a_separator_spelling_is_a_different_project_and_is_not_exempt(self):
+        # PEP 503 collapses a run of separators to one hyphen, it does not
+        # delete it, so py-yaml is not PyYAML and must not inherit its exemption.
+        self._check("py_yaml==6.0.3", installed_version="6.0")
+        self.assertEqual(
+            {"py_yaml": {"version_required": "==6.0.3", "version_found": "6.0"}},
+            self.conflicts,
+        )
+
     def test_non_exempt_package_conflict_still_recorded(self):
         self._check("opentelemetry-sdk==1.43.0", installed_version="1.20.0")
         self.assertEqual(

--- a/packaging/common/python/test_sitecustomize.py
+++ b/packaging/common/python/test_sitecustomize.py
@@ -68,6 +68,49 @@ def _load_benign(extra_env=None):
     return module, buf
 
 
+class NormalizedPackageNameTests(unittest.TestCase):
+    """The PEP 503 rule: runs of -, _ and . collapse to one -, then lowercase."""
+
+    def setUp(self):
+        self.module, self.stderr = _load_benign()
+
+    def test_canonical_name_is_unchanged(self):
+        self.assertEqual(
+            "opentelemetry-sdk", self.module._normalized_package_name("opentelemetry-sdk"))
+
+    def test_separators_become_hyphens(self):
+        for spelling in ("opentelemetry_sdk", "opentelemetry.sdk", "opentelemetry-sdk"):
+            with self.subTest(spelling=spelling):
+                self.assertEqual(
+                    "opentelemetry-sdk", self.module._normalized_package_name(spelling))
+
+    def test_runs_of_separators_collapse_to_one(self):
+        self.assertEqual(
+            "opentelemetry-sdk", self.module._normalized_package_name("opentelemetry_-.sdk"))
+
+    def test_case_is_folded(self):
+        self.assertEqual("pyyaml", self.module._normalized_package_name("PyYAML"))
+
+    def test_real_world_names_normalize_as_the_specification_says(self):
+        # Every one of these is a real PyPI distribution whose declared Name
+        # differs from its normalized form.
+        expected = {
+            "PyYAML": "pyyaml",
+            "typing_extensions": "typing-extensions",
+            "ruamel.yaml": "ruamel-yaml",
+            "zope.interface": "zope-interface",
+            "backports.tarfile": "backports-tarfile",
+        }
+        for declared, normalized in expected.items():
+            with self.subTest(declared=declared):
+                self.assertEqual(normalized, self.module._normalized_package_name(declared))
+
+    def test_distinct_names_stay_distinct(self):
+        self.assertNotEqual(
+            self.module._normalized_package_name("opentelemetry-sdk"),
+            self.module._normalized_package_name("opentelemetry-sdk-extras"))
+
+
 class CheckDependencyVersionConflictTests(unittest.TestCase):
     """Fine-grained tests for _check_dependency_version_conflict."""
 
@@ -464,6 +507,47 @@ class ImportDistroTests(unittest.TestCase):
         self._assert_deactivated(auto_instrumentation, observed_env)
         self.assertIn("already instrumented", output)
         self.assertIn("opentelemetry-sdk 1.20.0 (/app/site-packages)", output)
+
+    def test_deactivates_whatever_spelling_the_declared_name_uses(self):
+        # The Name a distribution declares is reported verbatim, and
+        # non-canonical spellings are ordinary on PyPI, so every spelling of a
+        # listed package has to be recognised.
+        for spelling in (
+            "opentelemetry_sdk",
+            "OpenTelemetry-SDK",
+            "OpenTelemetry_SDK",
+            "opentelemetry.sdk",
+            "OPENTELEMETRY-SDK",
+            "opentelemetry--sdk",
+        ):
+            with self.subTest(declared_name=spelling):
+                dist = MagicMock()
+                dist.metadata = {"Name": spelling}
+                dist.version = "1.20.0"
+                dist.locate_file.return_value = "/app/site-packages"
+                output, auto_instrumentation, observed_env = self._exec_sitecustomize(
+                    extra_env={"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"},
+                    all_dependencies="foo==1.0.0\n",
+                    installed_distributions=[dist],
+                )
+                self._assert_deactivated(auto_instrumentation, observed_env)
+                self.assertIn("already instrumented", output)
+                # Reported under the name the package declared, which is what
+                # the operator will see in pip list, not the normalized form
+                # the guard matched on.
+                self.assertIn(
+                    "{} 1.20.0 (/app/site-packages)".format(spelling), output)
+
+    def test_a_name_that_merely_starts_the_same_does_not_deactivate(self):
+        # Normalizing must not turn the membership test into a prefix match.
+        dist = MagicMock()
+        dist.metadata = {"Name": "opentelemetry_sdk_extras"}
+        output, auto_instrumentation, observed_env = self._exec_sitecustomize(
+            extra_env={"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"},
+            all_dependencies="foo==1.0.0\n",
+            installed_distributions=[dist],
+        )
+        self._assert_activated(auto_instrumentation, observed_env)
 
     def test_unrelated_installed_distribution_does_not_deactivate(self):
         dist = MagicMock()


### PR DESCRIPTION
Fixes #104.

`importlib.metadata` reports the `Name` each package declared, verbatim. The double-instrumentation guard compared that raw value against a list of canonical names, so only one spelling of each listed package was recognised.

## Observed, before and after

`python:3.12-slim`, bundle-shaped layout: `sitecustomize.py` and `all-dependencies.txt` in `/agent/glibc`, an application site at `/appsite`, `PYTHONPATH=/agent/glibc:/appsite`. Each run installs `opentelemetry-sdk` into the application site under a different declared `Name`.

| declared `Name` | before | after |
|---|---|---|
| `opentelemetry-sdk` | detected | unchanged |
| `opentelemetry_sdk` | **evades** | detected |
| `OpenTelemetry-SDK` | **evades** | detected |
| `OpenTelemetry_SDK` | **evades** | detected |
| `opentelemetry.sdk` | **evades** | detected |
| `OPENTELEMETRY-SDK` | **evades** | detected |
| `opentelemetry_sdk_extras` | not detected | unchanged |
| `flask` | not detected | unchanged |

Five of six spellings of the same distribution walked past the guard, and the agent then activated on top of an application already carrying the SDK. The last two rows are the regression check: normalising must not turn the membership test into a prefix match, and must not start matching unrelated packages.

## Non-canonical names are ordinary

Installing five well-known packages into a clean `python:3.12-slim`, five of the six distributions present declare a `Name` that differs from its normalised form: `PyYAML`, `typing_extensions`, `ruamel.yaml`, `zope.interface`, `backports.tarfile`. Only `pip` is already canonical. PEP 503 exists precisely because of this, and PEP 685 extends the rule to metadata.

## The codebase already half-knew

`importlib.metadata` normalises the name a distribution is looked *up* by: `distribution("opentelemetry-sdk")`, `distribution("opentelemetry_sdk")`, `distribution("OpenTelemetry-SDK")` and `distribution("opentelemetry.sdk")` all resolve to the same installed distribution. So the version-conflict lookup was already correct for free, and only the comparisons against our own hardcoded lists were not.

And the exemption test read `req.name.lower()`, which is the case half of the rule applied in one place. `PyYAML` is in the exempt list as `pyyaml`, so the case half was clearly hit and patched locally while the separator half and the other call site were not.

## Commits

1. `fix(python)`: the helper, applied in the double-instrumentation guard. This is the defect, and the input is application-controlled.
2. `refactor(python)`: apply it at the exemption test too, replacing the `.lower()`. **No behaviour change today** — neither exempt entry contains a separator, so `.lower()` and full normalisation agree. It is here so the two list comparisons cannot drift apart again, which is how one ended up normalising and the other not.
3. `test(python)`: assert both lists are written in normalised form.

## Why `import re` is inside the helper

`re` is not in `sys.modules` when `sitecustomize.py` runs, on any of 3.10 through 3.14 (measured). A module-scope import would therefore add startup cost to every Python process on the host, which is what the deferred `import logging` from #96 exists to avoid. But both call sites already `import importlib.metadata`, and that pulls in `re` itself, so by the time either comparison happens the import is free. `re.sub(r"[-_.]+", "-", name).lower()` is the PEP 503 reference expression and parses under Python 2.7.

## Verified

- The unit suite, 50 tests. The six spelling cases fail against `upstream/main`'s `sitecustomize.py` with the new tests in place.
- `TestSitecustomizePythonVersionCompatibility`, all four interpreters.
- `python2.7 -m py_compile`, so the parse contract on line 11 holds.
- The eight cases in the table above, before and after, on a real bundle-shaped layout.

## Notes for review

**Only the incoming name is normalised**, once per candidate, rather than normalising every list entry for every candidate. That makes it an invariant that the lists are written canonically, since an entry that is not can never match. Commit 3 enforces it: de-canonicalising a single entry silently disables the guard for that package while the list still looks right, and without those two tests the only symptoms are downstream failures that do not name the offending entry.

**A boundary worth knowing.** PEP 503 collapses a run of separators to one hyphen, it does not delete it, so `py_yaml` normalises to `py-yaml`, a different project from `PyYAML`, and does not inherit its exemption. There is a test pinning that, because the intuitive reading of "normalise" is that separators vanish.

**No documentation change.** The README and man page describe the check by what it does, not by how names are matched.

**Independent of #99, #101 and #103.** #103 edits the contents of the same list while this changes how the list is searched, so if #103 lands first this rebases cleanly and its added entries are simply matched by the normalised comparison too. #99 touches the body of `_check_for_double_instrumentation` (`dist._path` to `locate_file`) on the line below. All of them insert into `test_sitecustomize.py` at different anchors, so any conflict resolves by keeping both sides.
