### PR TITLE
fix(python): report every dependency conflict, not just the first

### DIFF
--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -365,14 +365,7 @@ def import_distro():
         _print_cannot_auto_instrument_message("cannot read all-dependencies.txt for dependency conflict checking")
         return
 
-    # Every requirement is checked, not just up to the first conflict. The
-    # deactivation warning is the only report an operator gets, so stopping
-    # early charges them one process restart per conflict to discover the rest,
-    # and which one they see is decided by the sorted order of the manifest.
-    # This costs nothing on the path that matters: with no conflicts the loop
-    # ran every requirement anyway. It costs one full pass over the manifest in
-    # the case that is about to deactivate, which is skipping the whole SDK and
-    # every instrumentor regardless.
+    # Check every requirement, not just up to the first conflict.
     for req_string in requirements_to_check:
         _check_dependency_version_conflict(req_string, version_conflicts)
 

--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -264,6 +264,23 @@ def _validate_config_file(current_site, config_file):
     return None
 
 
+def _render_version_conflicts(version_conflicts):
+    # Rendered as a list of problems rather than as the repr of the dict that
+    # holds them. One entry as a nested dict repr was merely unpolished; now
+    # that every conflict is reported, a manifest with several of them would
+    # otherwise put a wall of nested braces on the one line an operator reads.
+    # Sorted so the same set of conflicts always reads the same way.
+    descriptions = []
+    for name in sorted(version_conflicts):
+        conflict = version_conflicts[name]
+        if "error" in conflict:
+            descriptions.append("{} ({})".format(name, conflict["error"]))
+        else:
+            descriptions.append("{} (requires {}, found {})".format(
+                name, conflict["version_required"], conflict["version_found"]))
+    return "; ".join(descriptions)
+
+
 def _exporter_for_protocol(otlp_protocol):
     # This package bundles pure-Python OTLP exporters for both gRPC and
     # HTTP/protobuf (the gRPC one transports over the stdlib-only _pygrpc
@@ -392,7 +409,8 @@ def import_distro():
                     type(e).__name__, e))
     else:
         _self_deactivate(current_site)
-        _print_cannot_auto_instrument_message("dependency conflicts: {}".format(version_conflicts))
+        _print_cannot_auto_instrument_message(
+            "dependency conflicts: {}".format(_render_version_conflicts(version_conflicts)))
 
 
 # Every guard above exists to leave the process in a known state, and an

--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -353,10 +353,16 @@ def import_distro():
         _print_cannot_auto_instrument_message("cannot read all-dependencies.txt for dependency conflict checking")
         return
 
+    # Every requirement is checked, not just up to the first conflict. The
+    # deactivation warning is the only report an operator gets, so stopping
+    # early charges them one process restart per conflict to discover the rest,
+    # and which one they see is decided by the sorted order of the manifest.
+    # This costs nothing on the path that matters: with no conflicts the loop
+    # ran every requirement anyway. It costs one full pass over the manifest in
+    # the case that is about to deactivate, which is skipping the whole SDK and
+    # every instrumentor regardless.
     for req_string in requirements_to_check:
         _check_dependency_version_conflict(req_string, version_conflicts)
-        if version_conflicts:
-            break
 
     if not version_conflicts:
         if not config_file:

--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -265,11 +265,6 @@ def _validate_config_file(current_site, config_file):
 
 
 def _render_version_conflicts(version_conflicts):
-    # Rendered as a list of problems rather than as the repr of the dict that
-    # holds them. One entry as a nested dict repr was merely unpolished; now
-    # that every conflict is reported, a manifest with several of them would
-    # otherwise put a wall of nested braces on the one line an operator reads.
-    # Sorted so the same set of conflicts always reads the same way.
     descriptions = []
     for name in sorted(version_conflicts):
         conflict = version_conflicts[name]

--- a/packaging/common/python/test_sitecustomize.py
+++ b/packaging/common/python/test_sitecustomize.py
@@ -328,6 +328,31 @@ class ImportDistroTests(unittest.TestCase):
         self._assert_deactivated(auto_instrumentation, observed_env)
         self.assertIn("dependency conflicts", output)
 
+    def test_every_conflict_is_reported_not_just_the_first(self):
+        # The warning is the only report an operator gets, so stopping at the
+        # first conflict charges them a process restart per conflict to find
+        # the rest, and the manifest is sorted, so which one they are shown is
+        # decided by alphabetical order rather than by the problem.
+        output, auto_instrumentation, observed_env = self._exec_sitecustomize(
+            extra_env={"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"},
+            all_dependencies="alpha==2.0.0\nbeta==2.0.0\ngamma==2.0.0\n",
+            installed_version="1.0.0",
+        )
+        self._assert_deactivated(auto_instrumentation, observed_env)
+        for name in ("alpha", "beta", "gamma"):
+            self.assertIn(name, output)
+
+    def test_a_later_conflict_does_not_hide_an_earlier_one(self):
+        # Guards the accumulation: a conflict found later must add to what the
+        # loop already collected rather than replace it.
+        output, auto_instrumentation, observed_env = self._exec_sitecustomize(
+            extra_env={"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"},
+            all_dependencies="zulu==2.0.0\nalpha==2.0.0\n",
+            installed_version="1.0.0",
+        )
+        self.assertIn("zulu", output)
+        self.assertIn("alpha", output)
+
     def test_activates_with_grpc_when_protocol_unset(self):
         # An unset protocol follows the OTel default of grpc, which this
         # package now bundles (over the pure-Python transport).

--- a/packaging/common/python/test_sitecustomize.py
+++ b/packaging/common/python/test_sitecustomize.py
@@ -179,6 +179,49 @@ class CheckDependencyVersionConflictTests(unittest.TestCase):
         )
 
 
+class RenderVersionConflictsTests(unittest.TestCase):
+    """How a set of conflicts reads on the one line an operator gets."""
+
+    def setUp(self):
+        self.module, self.stderr = _load_benign()
+
+    def test_a_version_mismatch_names_both_versions(self):
+        self.assertEqual(
+            "foo (requires ==2.0.0, found 1.0.0)",
+            self.module._render_version_conflicts(
+                {"foo": {"version_required": "==2.0.0", "version_found": "1.0.0"}}),
+        )
+
+    def test_a_missing_package_reports_its_error(self):
+        self.assertEqual(
+            "foo (required package not found)",
+            self.module._render_version_conflicts(
+                {"foo": {"error": "required package not found"}}),
+        )
+
+    def test_the_two_kinds_appear_together(self):
+        self.assertEqual(
+            "alpha (requires ==2.0.0, found 1.0.0); beta (required package not found)",
+            self.module._render_version_conflicts({
+                "alpha": {"version_required": "==2.0.0", "version_found": "1.0.0"},
+                "beta": {"error": "required package not found"},
+            }),
+        )
+
+    def test_the_order_does_not_depend_on_insertion(self):
+        # The same set of conflicts has to read the same way every run.
+        forwards = self.module._render_version_conflicts({
+            "alpha": {"error": "required package not found"},
+            "zulu": {"error": "required package not found"},
+        })
+        backwards = self.module._render_version_conflicts({
+            "zulu": {"error": "required package not found"},
+            "alpha": {"error": "required package not found"},
+        })
+        self.assertEqual(forwards, backwards)
+        self.assertTrue(forwards.startswith("alpha"))
+
+
 class ImportDistroTests(unittest.TestCase):
     """End-to-end tests: execute sitecustomize.py under controlled conditions."""
 
@@ -352,6 +395,19 @@ class ImportDistroTests(unittest.TestCase):
         )
         self.assertIn("zulu", output)
         self.assertIn("alpha", output)
+
+    def test_the_conflicts_read_as_a_list_of_problems(self):
+        output, auto_instrumentation, observed_env = self._exec_sitecustomize(
+            extra_env={"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"},
+            all_dependencies="alpha==2.0.0\nbeta==2.0.0\n",
+            installed_version="1.0.0",
+        )
+        self.assertIn(
+            "dependency conflicts: alpha (requires ==2.0.0, found 1.0.0); "
+            "beta (requires ==2.0.0, found 1.0.0)",
+            output,
+        )
+        self.assertNotIn("{", output)
 
     def test_activates_with_grpc_when_protocol_unset(self):
         # An unset protocol follows the OTel default of grpc, which this


### PR DESCRIPTION
Fixes #108.

The dependency-conflict loop stopped at the first conflict, while the message it feeds is worded plural and everything beneath it is built to carry many. `version_conflicts` is a dict, `_check_dependency_version_conflict` accumulates into it by reference, and `test_conflicts_accumulate_across_calls` already asserted it holds more than one. Only the caller stopped early.

## Observed, before and after

Bundle-shaped layout on `python:3.12-slim`, `all-dependencies.txt` holding five pins that cannot be satisfied.

Before, the whole report:

```
... WARNING: cannot auto-instrument Python process: dependency conflicts: {'PyYAML': {'error': 'required package not found'}} [-c]
```

After:

```
... WARNING: cannot auto-instrument Python process: dependency conflicts: PyYAML (required package not found); alpha-package (required package not found); beta-package (required package not found); gamma-package (required package not found); opentelemetry-sdk (required package not found) [-c]
```

Mixed kinds render together:

```
... dependency conflicts: alpha-package (required package not found); beta-package (required package not found); packaging (requires ==99.0.0, found 26.3) [-c]
```

One of five became five of five. The manifest is sorted by the builder, so previously which conflict an operator saw was decided by alphabetical order rather than by anything about the problem, and each one cost a process restart to reach the next. The agent runs in every process on the host, so that restart is the workload's, not a shell's.

## What removing the `break` costs

Measured on a real install of the bundle's resolved set, 69 pins, on `python:3.12-slim`:

| | no conflicts | 3 conflicts among 72 pins |
|---|---|---|
| with the `break` | 15.7 ms | 0.09 ms, 1 conflict reported |
| without it | 19.5 ms | 16.5 ms, 3 conflicts reported |

The two columns say different things.

**On the path that matters, nothing changes.** With no conflicts the `break` never fires, so the loop already walked every pin. That is the common case and the one on the startup path of every instrumented process; the two numbers there differ only by measurement noise.

**In the conflict case it costs about one full pass**, in a process that is on its way to deactivating and running with no instrumentation at all. That process is about to skip loading the SDK and every instrumentor, which costs orders of magnitude more than 16 ms. And 16 ms is the worst case, with the conflict on the first pin; the manifest is sorted, so a conflict usually sits partway down and the loop was going to walk most of it anyway.

For what it is worth, the `break` was not a considered optimisation. It has been there since the file was added in #18.

## Commits

1. `fix(python)`: drop the `break`, with two tests. One asserts all three of three conflicts are named; the other asserts a later conflict adds to rather than replaces what the loop already collected.
2. `refactor(python)`: render the conflicts as a list of problems instead of the repr of the dict holding them. **Separable** — drop it if you would rather leave the wire format alone.

## Why the second commit belongs here

With one entry, `"dependency conflicts: {}".format(version_conflicts)` was merely unpolished. Once every conflict is reported, a manifest with several of them puts a wall of nested braces on the one line an operator reads, so the first commit makes the rendering matter in a way it did not before. The output is sorted, so the same set of conflicts always reads the same way.

Nothing depends on the old rendering: the existing tests assert on the `version_conflicts` dict, which is unchanged, plus the substring `dependency conflicts`, and no Go integration test looks at this message.

## Verified

- The unit suite, 45 tests. The two new behaviour assertions fail against `upstream/main`'s `sitecustomize.py`.
- `TestSitecustomizePythonVersionCompatibility`, all four interpreters.
- `python2.7 -m py_compile`, so the parse contract on line 11 holds.
- The cases above on a real bundle-shaped layout, plus two no-conflict runs (a satisfiable manifest and an empty one) confirming both still pass the check and reach `initialize()`.

## Notes for review

**`_render_version_conflicts` distinguishes the two shapes** the accumulator produces: `{"error": ...}` for a package that is not installed, and `{"version_required": ..., "version_found": ...}` for a version mismatch. There are unit tests for each and for the two appearing together.

**Independent of #99, #101, #103, #105 and #107.** #101 touches the exporter-selection lines in the same `if not version_conflicts:` block but not the loop above it nor the `else:` below it. The rest are elsewhere in the file. All insert into `test_sitecustomize.py` at different anchors, so any conflict resolves by keeping both sides.
