### PR TITLE
fix(python): accept any logging level name in OTEL_INJECTOR_LOG_LEVEL

### DIFF
--- a/packaging/common/python/README.md
+++ b/packaging/common/python/README.md
@@ -53,7 +53,11 @@ exporters (they emit protobuf only).
 - `OTEL_METRICS_EXPORTER`: Metrics exporter (default follows that signal's protocol)
 - `OTEL_LOGS_EXPORTER`: Logs exporter (default follows that signal's protocol)
 - `OTEL_PYTHON_DISABLED_INSTRUMENTATIONS`: Comma-separated list of instrumentations to disable
-- `OTEL_INJECTOR_LOG_LEVEL`: Set to `debug` for verbose sitecustomize.py logging
+- `OTEL_INJECTOR_LOG_LEVEL`: Severity threshold for `sitecustomize.py`'s own diagnostics.
+  Accepts `critical`, `error`, `warning`, `warn`, `info` and `debug`, in any case.
+  Defaults to `warning`; set `debug` for a verbose run. A level above `warning` is
+  accepted but clamped to it, because a warning is the only report you get when a
+  guard deactivates the agent. A value that is not a level is reported and ignored.
 
 ### Diagnostics
 
@@ -65,8 +69,8 @@ exporters (they emit protobuf only).
 ```
 
 A `WARNING` is always emitted, and it is the only report you get when a safety
-guard deactivates the agent. `DEBUG` records are emitted only when
-`OTEL_INJECTOR_LOG_LEVEL=debug`.
+guard deactivates the agent, so no value of `OTEL_INJECTOR_LOG_LEVEL` can silence
+one. `DEBUG` records are emitted only when `OTEL_INJECTOR_LOG_LEVEL=debug`.
 
 The records are `logging` records at `logging.WARNING` and `logging.DEBUG`, but
 they never enter the application's logging. The agent runs during `site` import,

--- a/packaging/common/python/opentelemetry-python.8.tmpl
+++ b/packaging/common/python/opentelemetry-python.8.tmpl
@@ -83,9 +83,23 @@ Set the logs exporter (default follows the protocol).
 Comma-separated list of instrumentation packages to disable.
 .TP
 .B OTEL_INJECTOR_LOG_LEVEL
-Set to
+Severity threshold for sitecustomize.py's own diagnostics. Accepts
+.BR critical ,
+.BR error ,
+.BR warning ,
+.BR warn ,
+.B info
+and
+.BR debug ,
+in any case, and defaults to
+.BR warning ;
+set
 .B debug
-to enable verbose logging from sitecustomize.py.
+for a verbose run. A level above
+.B warning
+is accepted but clamped to it, because a warning is the only report emitted when
+a guard deactivates the agent. A value that is not a level is reported and
+ignored.
 .TP
 .B OTEL_CONFIG_FILE
 Path to a declarative configuration file.

--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -53,7 +53,45 @@ version_conflict_exempt_packages = [
     "jsonschema",
 ]
 
-debug_enabled = environ.get("OTEL_INJECTOR_LOG_LEVEL") == "debug"
+# The levels OTEL_INJECTOR_LOG_LEVEL accepts, mapped to the numbers logging
+# uses. Spelled out rather than read from logging, because this is resolved at
+# module scope and importing logging here would cost every Python process on
+# the host, which is the whole point of _get_logger. These are logging's
+# documented constants, fixed by its own API.
+log_level_by_name = {
+    "critical": 50,
+    "error": 40,
+    "warn": 30,
+    "warning": 30,
+    "info": 20,
+    "debug": 10,
+}
+
+# A warning is the only report an operator gets when a guard deactivates the
+# agent, so no configured level may silence one. A level above WARNING is
+# accepted and clamped to it rather than honoured literally.
+default_log_level = log_level_by_name["warning"]
+
+
+def _resolve_log_level(value):
+    # Returns (level, unrecognized value). An unrecognized value is handed back
+    # to be reported rather than quietly meaning "off", which is what made this
+    # variable read as a boolean: only the exact string "debug" did anything, so
+    # DEBUG, info and warning all produced silence with nothing to explain it.
+    if value is None or not value.strip():
+        return default_log_level, None
+    level = log_level_by_name.get(value.strip().lower())
+    if level is None:
+        return default_log_level, value
+    return min(level, default_log_level), None
+
+
+injector_log_level, unrecognized_log_level = _resolve_log_level(
+    environ.get("OTEL_INJECTOR_LOG_LEVEL"))
+
+# Kept as its own name because it guards more than the logger's level: it is
+# what stops a process that is not in debug from importing logging at all.
+debug_enabled = injector_log_level <= log_level_by_name["debug"]
 
 _logger = None
 
@@ -68,7 +106,7 @@ def _get_logger():
     global _logger
     if _logger is not None:
         return _logger
-    from logging import DEBUG, WARNING, Formatter, Logger, StreamHandler
+    from logging import Formatter, Logger, StreamHandler
 
     class _SilentStreamHandler(StreamHandler):
         # A diagnostic that cannot be written must fail silently, which is what
@@ -107,7 +145,7 @@ def _get_logger():
     # every record with a "No handlers could be found" line instead). Owning
     # the level and the handler bypasses both, so a debug run is verbose on
     # every interpreter this file can reach.
-    logger.setLevel(DEBUG if debug_enabled else WARNING)
+    logger.setLevel(injector_log_level)
     _logger = logger
     return _logger
 

--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -161,6 +161,18 @@ def _log_debug(message):
         _get_logger().debug(message)
 
 
+if unrecognized_log_level is not None:
+    # Reported rather than silently treated as "off". This is the variable an
+    # operator reaches for to make the agent explain itself, so answering a
+    # typo with silence leaves them unable to tell a rejected value from a
+    # working one that had nothing to say. It does mean a process with a
+    # mistyped value pays the import logging this file otherwise avoids, which
+    # stops as soon as the value is corrected.
+    _log_warn(
+        'OTEL_INJECTOR_LOG_LEVEL="{}" is not a level; using warning. '
+        "Supported levels: {}.".format(
+            unrecognized_log_level, ", ".join(sorted(log_level_by_name))))
+
 _log_debug("running sitecustomize.py")
 _log_debug("PYTHONPATH: {}".format(environ.get("PYTHONPATH")))
 

--- a/packaging/common/python/test_sitecustomize.py
+++ b/packaging/common/python/test_sitecustomize.py
@@ -991,6 +991,83 @@ class DoubleInstrumentationPackageListTests(unittest.TestCase):
         self.assertEqual(len(set(packages)), len(packages))
 
 
+class LogLevelTests(unittest.TestCase):
+    """What OTEL_INJECTOR_LOG_LEVEL accepts.
+
+    It is named for a level, so it has to take one. It is also the documented
+    way to make the agent explain itself, so a value it does not understand
+    must say so rather than quietly mean "off".
+    """
+
+    def _resolve(self, value):
+        module, _ = _load_benign()
+        return module._resolve_log_level(value)
+
+    def test_every_level_name_is_accepted_in_any_case(self):
+        for spelling, expected in (
+            ("debug", 10), ("DEBUG", 10), ("Debug", 10), ("  debug  ", 10),
+            ("info", 20), ("INFO", 20),
+            ("warning", 30), ("warn", 30), ("WARNING", 30),
+        ):
+            with self.subTest(spelling=spelling):
+                level, unrecognized = self._resolve(spelling)
+                self.assertEqual(expected, level)
+                self.assertIsNone(unrecognized)
+
+    def test_a_level_above_warning_is_clamped_not_honoured(self):
+        # A warning is the only report an operator gets when a guard
+        # deactivates the agent, so no level may turn it off.
+        for spelling in ("error", "critical", "ERROR"):
+            with self.subTest(spelling=spelling):
+                level, unrecognized = self._resolve(spelling)
+                self.assertEqual(30, level)
+                self.assertIsNone(unrecognized)
+
+    def test_unset_or_empty_means_warning(self):
+        for value in (None, "", "   "):
+            with self.subTest(value=value):
+                level, unrecognized = self._resolve(value)
+                self.assertEqual(30, level)
+                self.assertIsNone(unrecognized)
+
+    def test_an_unrecognized_value_is_handed_back_verbatim(self):
+        for value in ("trace", "verbose", "1", "true"):
+            with self.subTest(value=value):
+                level, unrecognized = self._resolve(value)
+                self.assertEqual(30, level)
+                self.assertEqual(value, unrecognized)
+
+    def test_debug_is_the_only_level_that_emits_debug_records(self):
+        for value, enabled in (
+            ("debug", True), ("DEBUG", True),
+            ("info", False), ("warning", False), ("error", False),
+            ("trace", False), (None, False),
+        ):
+            with self.subTest(value=value):
+                module, buf = _load_benign(
+                    extra_env={} if value is None else {"OTEL_INJECTOR_LOG_LEVEL": value})
+                module._log_debug("a trace")
+                self.assertEqual(enabled, "a trace" in buf.getvalue())
+
+    def test_no_level_silences_a_warning(self):
+        for value in ("debug", "info", "warning", "error", "critical", "trace"):
+            with self.subTest(value=value):
+                module, buf = _load_benign(extra_env={"OTEL_INJECTOR_LOG_LEVEL": value})
+                module._log_warn("a diagnostic")
+                self.assertIn("a diagnostic", buf.getvalue())
+
+    def test_a_non_debug_level_still_never_builds_the_logger(self):
+        # The short circuit in _log_debug is what keeps a process that is not in
+        # debug from importing logging at all; making the variable level-aware
+        # must not trade that away.
+        for value in ("info", "warning", "error"):
+            with self.subTest(value=value):
+                module, _ = _load_benign(extra_env={"OTEL_INJECTOR_LOG_LEVEL": value})
+                module._logger = None
+                module._log_debug("a trace")
+                self.assertIsNone(module._logger)
+
+
 class LoggingTests(unittest.TestCase):
     """The contract of the diagnostics channel.
 

--- a/packaging/common/python/test_sitecustomize.py
+++ b/packaging/common/python/test_sitecustomize.py
@@ -1056,6 +1056,29 @@ class LogLevelTests(unittest.TestCase):
                 module._log_warn("a diagnostic")
                 self.assertIn("a diagnostic", buf.getvalue())
 
+    def test_an_unrecognized_value_is_reported_at_load(self):
+        # The whole point of the variable is to make the agent explain itself,
+        # so answering a typo with silence is the one thing it must not do.
+        buf = StringIO()
+        env = {
+            k: v for k, v in os.environ.items()
+            if k not in ("OTEL_EXPORTER_OTLP_PROTOCOL", "OTEL_CONFIG_FILE")
+        }
+        env["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/json"
+        env["OTEL_INJECTOR_LOG_LEVEL"] = "verbose"
+        with patch.dict(os.environ, env, clear=True), patch.object(sys, "path", list(sys.path)):
+            _load_sitecustomize(buf)
+        output = buf.getvalue()
+        self.assertIn('OTEL_INJECTOR_LOG_LEVEL="verbose" is not a level', output)
+        self.assertIn("debug", output)
+        self.assertIn("WARNING", output)
+
+    def test_a_recognized_value_reports_nothing_about_the_level(self):
+        for value in ("debug", "info", "warning", "error"):
+            with self.subTest(value=value):
+                module, buf = _load_benign(extra_env={"OTEL_INJECTOR_LOG_LEVEL": value})
+                self.assertNotIn("is not a level", buf.getvalue())
+
     def test_a_non_debug_level_still_never_builds_the_logger(self):
         # The short circuit in _log_debug is what keeps a process that is not in
         # debug from importing logging at all; making the variable level-aware


### PR DESCRIPTION
Fixes #110.

`OTEL_INJECTOR_LOG_LEVEL` was named for a level and behaved as a boolean: only the exact string `debug` did anything, and every other value, including every level name, silently meant "off".

## Observed, before and after

Bundle-shaped layout on `python:3.12-slim`, counting the records each value produces.

| value | DEBUG before | DEBUG after | WARNING after |
|---|---|---|---|
| `debug` | 7 | 7 | 1 |
| `DEBUG` | **0** | 7 | 1 |
| `Debug` | **0** | 7 | 1 |
| `info` | 0 | 0 | 1 |
| `warning` | 0 | 0 | 1 |
| `warn` | 0 | 0 | 1 |
| `error` | 0 | 0 | 1 |
| `critical` | 0 | 0 | 1 |
| `trace` | 0 | 0 | 2, one of them naming the bad value |
| empty | 0 | 0 | 1 |
| unset | 0 | 0 | 1 |

`DEBUG` is the spelling `logging` itself uses and the one an operator reaching for a variable named `_LOG_LEVEL` is most likely to try. It produced nothing, and nothing said so, which is the wrong failure mode for the variable whose job is to make the agent explain itself.