### PR TITLE
refactor(python): tidy-up in sitecustomize.py (misnamed function, path separator, redundant except, import style)

### DIFF
--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -11,8 +11,12 @@
 # IMPORTANT: This file must be valid Python 2.7+ so that it can be parsed without crashing
 # older interpreters. The version gate below prevents execution on unsupported versions.
 
-import os
-from os.path import dirname
+from os import environ, pathsep
+from os.path import dirname, isfile, join, normpath
+# sys is imported as a module, unlike everything else here, because
+# _log_cannot_auto_instrument_warning probes it with hasattr: sys.argv is
+# absent under some embedded interpreters, where "from sys import argv" would
+# raise at import time instead of letting the diagnostic degrade.
 import sys
 from sys import path, version, version_info, stderr
 
@@ -40,7 +44,7 @@ version_conflict_exempt_packages = [
     "jsonschema",
 ]
 
-debug_enabled = os.environ.get("OTEL_INJECTOR_LOG_LEVEL") == "debug"
+debug_enabled = environ.get("OTEL_INJECTOR_LOG_LEVEL") == "debug"
 
 _logger = None
 
@@ -49,15 +53,15 @@ def _get_logger():
     # logging is imported here rather than at module scope. The injector
     # prepends this file to every Python process on the host, including the
     # short-lived ones and the ones that deactivate at the version gate, and
-    # `import logging` costs 22 ms and 34 modules (threading, re, traceback)
+    # importing logging costs 22 ms and 34 modules (threading, re, traceback)
     # against 2.7 ms for site itself. A process that emits no diagnostic pays
     # none of it.
     global _logger
     if _logger is not None:
         return _logger
-    import logging
+    from logging import DEBUG, WARNING, Formatter, Logger, StreamHandler
 
-    class _SilentStreamHandler(logging.StreamHandler):
+    class _SilentStreamHandler(StreamHandler):
         # A diagnostic that cannot be written must fail silently, which is what
         # `print(file=stderr)` wrapped in `except Exception: pass` did.
         # Handler.handleError instead writes a "--- Logging error ---"
@@ -68,9 +72,9 @@ def _get_logger():
         def handleError(self, record):
             pass
 
-    class _SingleLineFormatter(logging.Formatter):
+    class _SingleLineFormatter(Formatter):
         def format(self, record):
-            return " ".join(logging.Formatter.format(self, record).split())
+            return " ".join(Formatter.format(self, record).split())
 
     # Built by instantiating logging.Logger directly instead of through
     # logging.getLogger(), so that nothing about the application's logging
@@ -79,7 +83,7 @@ def _get_logger():
     # while disabling existing loggers, and its parent is None, so no record
     # can reach the root handlers. getLogger() exists so that one name yields
     # one shared logger; here not sharing is the point.
-    logger = logging.Logger("opentelemetry-python-autoinstrumentation")
+    logger = Logger("opentelemetry-python-autoinstrumentation")
     # sys.stderr can be None (daemons, pythonw) or closed. The handler holds
     # the stream from construction, so a later replacement cannot silence the
     # diagnostics, and a write to a None or closed stream is dropped instead
@@ -94,7 +98,7 @@ def _get_logger():
     # every record with a "No handlers could be found" line instead). Owning
     # the level and the handler bypasses both, so a debug run is verbose on
     # every interpreter this file can reach.
-    logger.setLevel(logging.DEBUG if debug_enabled else logging.WARNING)
+    logger.setLevel(DEBUG if debug_enabled else WARNING)
     _logger = logger
     return _logger
 
@@ -111,7 +115,7 @@ def _log_debug(message):
 
 
 _log_debug("running sitecustomize.py")
-_log_debug("PYTHONPATH: {}".format(os.environ.get("PYTHONPATH")))
+_log_debug("PYTHONPATH: {}".format(environ.get("PYTHONPATH")))
 
 
 def _log_cannot_auto_instrument_warning(reason):
@@ -130,21 +134,21 @@ def _self_deactivate(current_site):
     # Remove this site from PYTHONPATH so child processes do not load it.
     # Compared normalized: the injected entry can differ textually from
     # dirname(__file__) (e.g. a trailing slash).
-    normalized_site = os.path.normpath(current_site)
-    current_pythonpath = os.environ.get("PYTHONPATH", "")
+    normalized_site = normpath(current_site)
+    current_pythonpath = environ.get("PYTHONPATH", "")
     pythonpath_entries = [
-        entry for entry in current_pythonpath.split(os.pathsep)
-        if os.path.normpath(entry) != normalized_site
+        entry for entry in current_pythonpath.split(pathsep)
+        if normpath(entry) != normalized_site
     ]
-    new_pythonpath = os.pathsep.join(pythonpath_entries)
+    new_pythonpath = pathsep.join(pythonpath_entries)
     _log_debug('setting PYTHONPATH in _self_deactivate: "{}"'.format(new_pythonpath))
-    os.environ["PYTHONPATH"] = new_pythonpath
+    environ["PYTHONPATH"] = new_pythonpath
 
     # Clear the injector's Python agent path so it does not re-add our site to child processes.
     _log_debug("clearing PYTHON_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX in _self_deactivate")
-    os.environ["PYTHON_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX"] = ""
+    environ["PYTHON_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX"] = ""
 
-    path[:] = [entry for entry in path if os.path.normpath(entry) != normalized_site]
+    path[:] = [entry for entry in path if normpath(entry) != normalized_site]
 
 
 def _normalized_package_name(name):
@@ -163,9 +167,9 @@ def _normalized_package_name(name):
 
 
 def _check_for_double_instrumentation(current_site):
-    import importlib.metadata
+    from importlib.metadata import distributions
     offending_packages = []
-    for dist in importlib.metadata.distributions():
+    for dist in distributions():
         # The location is read before the metadata because it is path
         # arithmetic that does not touch METADATA, so it is still available to
         # describe a distribution whose name turns out not to be readable.
@@ -207,7 +211,7 @@ def _check_for_double_instrumentation(current_site):
 
 def _read_all_dependencies():
     """Read all flattened dependencies from all-dependencies.txt. Returns list of requirement strings or None."""
-    dependencies_file = os.path.join(dirname(__file__), "all-dependencies.txt")
+    dependencies_file = join(dirname(__file__), "all-dependencies.txt")
     requirements_to_check = []
     try:
         # Decoded as UTF-8 explicitly rather than in whatever the locale says.
@@ -235,7 +239,7 @@ def _read_all_dependencies():
 
 def _check_dependency_version_conflict(req_string, version_conflicts):
     """Check for a dependency version conflict. Accumulates conflicts in version_conflicts (modified in place)."""
-    import importlib.metadata
+    from importlib.metadata import PackageNotFoundError, distribution
     from packaging.requirements import Requirement
     from packaging.version import Version
 
@@ -259,8 +263,8 @@ def _check_dependency_version_conflict(req_string, version_conflicts):
         return
 
     try:
-        installed_distribution = importlib.metadata.distribution(req.name)
-    except importlib.metadata.PackageNotFoundError:
+        installed_distribution = distribution(req.name)
+    except PackageNotFoundError:
         _log_debug("adding version error for {}".format(req.name))
         version_conflicts[req.name] = {"error": "required package not found"}
         return
@@ -310,14 +314,14 @@ def _validate_config_file(current_site, config_file):
     which case a debug/warning line explains why), and a human-readable error
     message when the file would break the SDK's file configurator.
     """
-    import subprocess
+    from subprocess import run
 
-    validator = os.path.join(dirname(current_site), "otel-config-check")
-    if not os.path.isfile(validator):
+    validator = join(dirname(current_site), "otel-config-check")
+    if not isfile(validator):
         _log_debug("otel-config-check not found at {}; skipping configuration file validation".format(validator))
         return None
     try:
-        result = subprocess.run([validator, config_file], capture_output=True, text=True, timeout=10)
+        result = run([validator, config_file], capture_output=True, text=True, timeout=10)
     except Exception as e:
         _log_warn("cannot run otel-config-check ({}: {}); skipping configuration file validation".format(
             type(e).__name__, e))
@@ -372,7 +376,7 @@ def import_distro():
     # Under OTEL_CONFIG_FILE the configuration file drives exporter selection
     # and OTEL_*_EXPORTER is ignored, so this default is inert in that mode.
     default_exporter = "otlp_proto_grpc"
-    config_file = os.environ.get("OTEL_CONFIG_FILE")
+    config_file = environ.get("OTEL_CONFIG_FILE")
     if config_file:
         # With OTEL_CONFIG_FILE in effect the SDK ignores the OTEL_* exporter
         # environment variables, so the protocol guard below would check
@@ -389,7 +393,7 @@ def import_distro():
     else:
         _log_debug("checking OTEL_EXPORTER_OTLP_PROTOCOL")
 
-        otlp_protocol = os.environ.get("OTEL_EXPORTER_OTLP_PROTOCOL")
+        otlp_protocol = environ.get("OTEL_EXPORTER_OTLP_PROTOCOL")
         default_exporter = _exporter_for_protocol(otlp_protocol)
         if default_exporter is None:
             _self_deactivate(current_site)
@@ -410,8 +414,8 @@ def import_distro():
     # value). Leaving the site on sys.path here would make the
     # double-instrumentation check see the bundle's own packages and falsely
     # self-deactivate; an unguarded exact remove() would raise instead.
-    normalized_site = os.path.normpath(current_site)
-    path[:] = [entry for entry in path if os.path.normpath(entry) != normalized_site]
+    normalized_site = normpath(current_site)
+    path[:] = [entry for entry in path if normpath(entry) != normalized_site]
 
     if _check_for_double_instrumentation(current_site):
         return
@@ -439,9 +443,9 @@ def import_distro():
             # replacements under the standard entry points. No-ops if the user
             # already set these. Skipped under OTEL_CONFIG_FILE, where the
             # configuration file drives exporter selection and these are ignored.
-            os.environ.setdefault("OTEL_TRACES_EXPORTER", default_exporter)
-            os.environ.setdefault("OTEL_METRICS_EXPORTER", default_exporter)
-            os.environ.setdefault("OTEL_LOGS_EXPORTER", default_exporter)
+            environ.setdefault("OTEL_TRACES_EXPORTER", default_exporter)
+            environ.setdefault("OTEL_METRICS_EXPORTER", default_exporter)
+            environ.setdefault("OTEL_LOGS_EXPORTER", default_exporter)
         try:
             _log_debug("importing and initializing the Python auto-instrumentation now")
             from opentelemetry.instrumentation import auto_instrumentation

--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -114,7 +114,7 @@ _log_debug("running sitecustomize.py")
 _log_debug("PYTHONPATH: {}".format(os.environ.get("PYTHONPATH")))
 
 
-def _print_cannot_auto_instrument_message(reason):
+def _log_cannot_auto_instrument_warning(reason):
     if hasattr(sys, "argv"):
         _log_warn("cannot auto-instrument Python process: {} [{}]".format(reason, " ".join(sys.argv)))
     else:
@@ -195,7 +195,7 @@ def _check_for_double_instrumentation(current_site):
             offending_packages.append("{} {} ({})".format(name, dist.version, dist.locate_file("")))
     if offending_packages:
         _self_deactivate(current_site)
-        _print_cannot_auto_instrument_message(
+        _log_cannot_auto_instrument_warning(
             "The application has OpenTelemetry dependencies which indicate that it is already instrumented. "
             "The following problematic dependencies have been found: {}. ".format(", ".join(offending_packages)) +
             "Skipping Python auto-instrumentation to avoid double instrumentation. Remove the mentioned "
@@ -361,7 +361,7 @@ def import_distro():
     # We cannot use named attributes (e.g. sys.version_info.major) as those were introduced in 3.1.
     if version_info[0] != 3 or version_info[1] < 10:
         _self_deactivate(current_site)
-        _print_cannot_auto_instrument_message("unsupported Python version: {}".format(version))
+        _log_cannot_auto_instrument_warning("unsupported Python version: {}".format(version))
         return
     _log_debug("found eligible Python version: {}".format(version_info))
 
@@ -379,7 +379,7 @@ def import_distro():
         validation_error = _validate_config_file(current_site, config_file)
         if validation_error is not None:
             _self_deactivate(current_site)
-            _print_cannot_auto_instrument_message(
+            _log_cannot_auto_instrument_warning(
                 "the configuration file set via OTEL_CONFIG_FILE ({}) is not usable: {}".format(
                     config_file, validation_error))
             return
@@ -390,7 +390,7 @@ def import_distro():
         default_exporter = _exporter_for_protocol(otlp_protocol)
         if default_exporter is None:
             _self_deactivate(current_site)
-            _print_cannot_auto_instrument_message(
+            _log_cannot_auto_instrument_warning(
                 "OTEL_EXPORTER_OTLP_PROTOCOL={} is not supported. "
                 "This package supports grpc and http/protobuf.".format(otlp_protocol)
             )
@@ -422,7 +422,7 @@ def import_distro():
     requirements_to_check = _read_all_dependencies()
     if requirements_to_check is None:
         _self_deactivate(current_site)
-        _print_cannot_auto_instrument_message("cannot read all-dependencies.txt for dependency conflict checking")
+        _log_cannot_auto_instrument_warning("cannot read all-dependencies.txt for dependency conflict checking")
         return
 
     # Check every requirement, not just up to the first conflict.
@@ -452,12 +452,12 @@ def import_distro():
             auto_instrumentation.initialize(swallow_exceptions=False)
         except Exception as e:
             _self_deactivate(current_site)
-            _print_cannot_auto_instrument_message(
+            _log_cannot_auto_instrument_warning(
                 "error when importing/initializing Python OpenTelemetry auto-instrumentation: {}: {}".format(
                     type(e).__name__, e))
     else:
         _self_deactivate(current_site)
-        _print_cannot_auto_instrument_message(
+        _log_cannot_auto_instrument_warning(
             "dependency conflicts: {}".format(_render_version_conflicts(version_conflicts)))
 
 
@@ -471,7 +471,7 @@ try:
     import_distro()
 except Exception as unexpected_error:
     try:
-        _print_cannot_auto_instrument_message(
+        _log_cannot_auto_instrument_warning(
             "unexpected error while deciding whether to auto-instrument: {}: {}".format(
                 type(unexpected_error).__name__, unexpected_error))
     except Exception:

--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -133,10 +133,10 @@ def _self_deactivate(current_site):
     normalized_site = os.path.normpath(current_site)
     current_pythonpath = os.environ.get("PYTHONPATH", "")
     pythonpath_entries = [
-        entry for entry in current_pythonpath.split(":")
+        entry for entry in current_pythonpath.split(os.pathsep)
         if os.path.normpath(entry) != normalized_site
     ]
-    new_pythonpath = ":".join(pythonpath_entries)
+    new_pythonpath = os.pathsep.join(pythonpath_entries)
     _log_debug('setting PYTHONPATH in _self_deactivate: "{}"'.format(new_pythonpath))
     os.environ["PYTHONPATH"] = new_pythonpath
 

--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -222,7 +222,10 @@ def _read_all_dependencies():
                     continue
                 requirements_to_check.append(line)
         return requirements_to_check
-    except (IOError, OSError, UnicodeDecodeError):
+    except (OSError, UnicodeDecodeError):
+        # IOError is an alias of OSError since 3.3, and this runs only behind
+        # the version_info gate on 3.10+, so naming both caught nothing extra.
+        #
         # A manifest that cannot be decoded is as unusable as one that cannot
         # be opened, and the caller already turns None into a deactivation that
         # names this file. Without UnicodeDecodeError here it would instead


### PR DESCRIPTION
Fixes #114.

Four small cleanups in `packaging/common/python/sitecustomize.py`, one per commit, none of them changing behaviour.

1. `refactor(python)`: rename `_print_cannot_auto_instrument_message`, which has not printed since #97 moved diagnostics to `logging`. One definition, eight call sites.
2. `refactor(python)`: split and join `PYTHONPATH` on `os.pathsep` instead of a literal `":"`.
3. `refactor(python)`: `except OSError` instead of `except (IOError, OSError)`.
4. `refactor(python)`: import names rather than modules throughout.

Each stands alone, so any of them can be dropped without disturbing the others.

## On commit 4

The file imported `os` and `sys` twice each, once in each style, so it read `dirname(...)` beside `os.path.join(...)` and `path[:]` beside `sys.argv`, and the function-local imports had the same split. Settling on `from x import y` removes the doubled imports and puts each function's dependencies at its own head.

**`sys` is the deliberate exception** and now carries a comment saying why. `_log_cannot_auto_instrument_warning` probes it with `hasattr(sys, "argv")` because `sys.argv` is absent under some embedded interpreters; a module-scope `from sys import argv` would raise there instead of letting the diagnostic degrade to its no-argv branch. That is a genuine need for the module object, so `import sys` stays.

**Import timing is unchanged.** `logging`, `importlib.metadata`, `packaging` and `subprocess` stay function-local. The comment at the top of `_get_logger` explains the cost that buys (22 ms and 34 modules a silent process should not pay), and it still applies verbatim. This changes import *style*, not import *timing*.

**The existing tests keep working, and keep testing.** They patch `importlib.metadata.distribution` and `importlib.metadata.distributions` at the source module. A `from x import y` inside a function body resolves at call time, so it reads the patched attribute and still receives the mock. This is not merely "the suite is green": had the patches stopped applying, the real `distributions()` would return the test environment's actual packages, which contain no `opentelemetry-sdk`, and the double-instrumentation assertions would fail rather than pass.

## Verified

- The unit suite, 40 tests, after each of the four commits.
- `python2.7 -m py_compile`, so the parse contract on line 11 holds. Commit 3 is the one that could have broken it, since `IOError` and `OSError` are distinct on 2.7; `_read_all_dependencies` only ever runs behind the `version_info` gate on 3.10+, so nothing that executes that line sees a difference.
- `TestSitecustomize` in `packaging/tests/python`, all interpreters, `ok 12.565s`.
- **A before/after behaviour diff on a bundle-shaped layout.** I ran `3e18ad7`'s file and this branch's file through the same seven scenarios in the same container (dependency conflict, `PYTHONPATH` rewriting with entries either side of the agent, unsupported protocol, rejected config file, accepted config file, a debug run, and double instrumentation) and diffed the combined output. **34 lines, byte-identical.** That is the evidence for the "no behaviour change" claim in each commit message.
- Separately, real `distributions()` against an installed `opentelemetry-sdk` still reports "already instrumented", and real `run()` still surfaces the validator's stderr.

## Notes for review

**This has the widest conflict surface of my open PRs and should go last.** The rename in commit 1 touches eight call sites spread across the file, and commit 4 touches `_get_logger`, `_self_deactivate`, `_check_for_double_instrumentation`, `_check_dependency_version_conflict` and `_validate_config_file`. Concretely it overlaps #105 (the double-instrumentation predicate), #107 (`_SingleLineFormatter`, which subclasses `logging.Formatter` inside `_get_logger`) and #111 (`logger.setLevel` in the same function). I am happy to rebase this onto whatever lands, in whatever order you prefer; merging the behaviour changes first and this last means the conflicts resolve mechanically rather than needing judgement.

**Based on `3e18ad7`**, so it includes #99.
