### PR TITLE
fix(python): a package with non-UTF-8 METADATA should not deactivate auto-instrumentation

### DIFF
--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -214,14 +214,23 @@ def _read_all_dependencies():
     dependencies_file = os.path.join(dirname(__file__), "all-dependencies.txt")
     requirements_to_check = []
     try:
-        with open(dependencies_file, "r") as f:
+        # Decoded as UTF-8 explicitly rather than in whatever the locale says.
+        # This file ships inside the bundle, so its encoding is a property of
+        # the package and not of the process that happens to be reading it: a
+        # C locale with PEP 538 coercion disabled decodes as ASCII, which would
+        # make the same bundle readable in one process and not in the next.
+        with open(dependencies_file, "r", encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 if not line or line.startswith("#"):
                     continue
                 requirements_to_check.append(line)
         return requirements_to_check
-    except (IOError, OSError):
+    except (IOError, OSError, UnicodeDecodeError):
+        # A manifest that cannot be decoded is as unusable as one that cannot
+        # be opened, and the caller already turns None into a deactivation that
+        # names this file. Without UnicodeDecodeError here it would instead
+        # surface as the blanket handler's "unexpected error".
         return None
 
 

--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -257,15 +257,27 @@ def _check_dependency_version_conflict(req_string, version_conflicts):
         version_conflicts[req.name] = {"error": "required package not found"}
         return
 
+    # Read the version out once, before parsing it. distribution() above is
+    # lazy and does not touch METADATA, so an unreadable file surfaces here,
+    # and holding the value in a local is what lets the parse handler below
+    # quote it without going back to the attribute that just failed.
+    try:
+        installed_version_string = installed_distribution.version
+    except Exception as e:
+        _log_warn(
+            'cannot read the installed version of package "{}"; skipping its '
+            "dependency-conflict check: {}: {}".format(req.name, type(e).__name__, e))
+        return
+
     # Distributions patched by Linux distros can carry versions that do not
     # parse as PEP 440 (and metadata may lack a version entirely).
     try:
-        installed_version = Version(installed_distribution.version)
+        installed_version = Version(installed_version_string)
     except Exception as e:
         _log_warn(
             'cannot parse the installed version "{}" of package "{}"; '
             "skipping its dependency-conflict check: {}: {}".format(
-                installed_distribution.version, req.name, type(e).__name__, e))
+                installed_version_string, req.name, type(e).__name__, e))
         return
 
     _log_debug("installed_version: {}".format(installed_version))

--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -166,7 +166,29 @@ def _check_for_double_instrumentation(current_site):
     import importlib.metadata
     offending_packages = []
     for dist in importlib.metadata.distributions():
-        name = dist.metadata["Name"]
+        # The location is read before the metadata because it is path
+        # arithmetic that does not touch METADATA, so it is still available to
+        # describe a distribution whose name turns out not to be readable.
+        location = "an unknown location"
+        try:
+            location = dist.locate_file("")
+            name = dist.metadata["Name"]
+        except Exception as e:
+            # importlib.metadata decodes METADATA as UTF-8, and a distribution
+            # whose file is not valid UTF-8 raises here; a Latin-1 author field
+            # written by older tooling is the usual cause. Skip that one
+            # distribution rather than letting it abort the scan, which
+            # deactivated the agent for the whole process over a package that
+            # has nothing to do with OpenTelemetry.
+            #
+            # Reported at WARNING, and by directory: the name is exactly what
+            # could not be read, so the directory is all that identifies it,
+            # and it is what the operator needs in order to fix the package.
+            _log_warn(
+                "cannot read the metadata of the distribution installed in {}, so it cannot be "
+                "checked for double instrumentation; skipping it: {}: {}".format(
+                    location, type(e).__name__, e))
+            continue
         if name is not None and _normalized_package_name(name) in double_instrumentation_check_packages:
             # The operator reading the deactivation message has to find and
             # remove this package, so name it with its version and its install

--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -180,10 +180,6 @@ def _check_for_double_instrumentation(current_site):
             # distribution rather than letting it abort the scan, which
             # deactivated the agent for the whole process over a package that
             # has nothing to do with OpenTelemetry.
-            #
-            # Reported at WARNING, and by directory: the name is exactly what
-            # could not be read, so the directory is all that identifies it,
-            # and it is what the operator needs in order to fix the package.
             _log_warn(
                 "cannot read the metadata of the distribution installed in {}, so it cannot be "
                 "checked for double instrumentation; skipping it: {}: {}".format(

--- a/packaging/common/python/test_sitecustomize.py
+++ b/packaging/common/python/test_sitecustomize.py
@@ -768,6 +768,61 @@ class ImportDistroTests(unittest.TestCase):
         self.assertIn("unexpected error while deciding whether to auto-instrument", output)
         self.assertIn("TypeError", output)
 
+    def test_undecodable_distribution_metadata_is_skipped_with_a_warning(self):
+        # importlib.metadata decodes METADATA as UTF-8, so a distribution whose
+        # file is not valid UTF-8 (a Latin-1 author field written by older
+        # tooling is the usual cause) raises when its name is read. Such a
+        # package is almost never an OpenTelemetry one, and it used to abort
+        # the whole scan and deactivate the agent for the process.
+        #
+        # A real object is used rather than a MagicMock, which answers to every
+        # attribute and so could not raise where this needs it to.
+        class DistributionWithUndecodableMetadata(object):
+            @property
+            def metadata(self):
+                raise UnicodeDecodeError("utf-8", b"\xe9", 0, 1, "invalid continuation byte")
+
+            def locate_file(self, path):
+                return "/app/site-packages"
+
+        output, auto_instrumentation, observed_env = self._exec_sitecustomize(
+            extra_env={"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"},
+            all_dependencies="foo==1.0.0\n",
+            installed_distributions=[DistributionWithUndecodableMetadata()],
+        )
+        self._assert_activated(auto_instrumentation, observed_env)
+        self.assertIn("cannot read the metadata", output)
+        # The name is what could not be read, so the directory is the only
+        # thing that identifies the package the operator has to go and fix.
+        self.assertIn("/app/site-packages", output)
+        self.assertIn("UnicodeDecodeError", output)
+
+    def test_an_undecodable_distribution_does_not_hide_a_real_one(self):
+        # Skipping the unreadable distribution must not cost the scan the
+        # distribution it exists to find, so a genuine offender behind a broken
+        # one is still detected and named.
+        class DistributionWithUndecodableMetadata(object):
+            @property
+            def metadata(self):
+                raise UnicodeDecodeError("utf-8", b"\xe9", 0, 1, "invalid continuation byte")
+
+            def locate_file(self, path):
+                return "/app/site-packages"
+
+        offender = MagicMock()
+        offender.metadata = {"Name": "opentelemetry-sdk"}
+        offender.version = "1.20.0"
+        offender.locate_file.return_value = "/app/site-packages"
+
+        output, auto_instrumentation, observed_env = self._exec_sitecustomize(
+            extra_env={"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"},
+            all_dependencies="foo==1.0.0\n",
+            installed_distributions=[DistributionWithUndecodableMetadata(), offender],
+        )
+        self._assert_deactivated(auto_instrumentation, observed_env)
+        self.assertIn("already instrumented", output)
+        self.assertIn("opentelemetry-sdk 1.20.0 (/app/site-packages)", output)
+
     def test_unexpected_error_deactivates_with_a_warning(self):
         # Only four steps inside import_distro() have a try block of their
         # own. An exception from any other step escaped into

--- a/packaging/common/python/test_sitecustomize.py
+++ b/packaging/common/python/test_sitecustomize.py
@@ -222,6 +222,31 @@ class CheckDependencyVersionConflictTests(unittest.TestCase):
         self.assertIn("WARN", output)
         self.assertIn("cannot parse the installed version", output)
 
+    def test_unreadable_installed_version_is_skipped_with_a_warning(self):
+        # distribution() is lazy and does not touch METADATA, so a file that is
+        # not valid UTF-8 surfaces here, at .version. The parse handler used to
+        # quote that attribute in its own message, reading it a second time,
+        # which raised again from inside the handler and escaped the function
+        # that exists to skip exactly this. A real object is used because a
+        # MagicMock cannot raise on attribute access.
+        class DistributionWithUndecodableMetadata(object):
+            @property
+            def version(self):
+                raise UnicodeDecodeError("utf-8", b"\xe9", 0, 1, "invalid continuation byte")
+
+        with patch(
+            "importlib.metadata.distribution",
+            return_value=DistributionWithUndecodableMetadata(),
+        ):
+            # Returning at all is the assertion: this raised before.
+            self.module._check_dependency_version_conflict("foo==1.0.0", self.conflicts)
+
+        self.assertEqual({}, self.conflicts)
+        output = self.stderr.getvalue()
+        self.assertIn("WARN", output)
+        self.assertIn('cannot read the installed version of package "foo"', output)
+        self.assertIn("UnicodeDecodeError", output)
+
     def test_conflicts_accumulate_across_calls(self):
         self._check("===bogus===")
         self._check("foo==2.0.0", installed_version="1.0.0")

--- a/packaging/common/python/test_sitecustomize.py
+++ b/packaging/common/python/test_sitecustomize.py
@@ -607,6 +607,19 @@ class ImportDistroTests(unittest.TestCase):
         self._assert_deactivated(auto_instrumentation, observed_env)
         self.assertIn("cannot read all-dependencies.txt", output)
 
+    def test_deactivates_when_dependencies_file_is_not_valid_utf8(self):
+        # A manifest that cannot be decoded is as unusable as one that cannot
+        # be opened, so it deactivates naming this file rather than reaching
+        # the blanket handler as an "unexpected error".
+        with open(os.path.join(self.site_dir, "all-dependencies.txt"), "wb") as f:
+            f.write(b"packaging==1.0.0\n# comentario en espa\xf1ol\n")
+        output, auto_instrumentation, observed_env = self._exec_sitecustomize(
+            extra_env={"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"},
+        )
+        self._assert_deactivated(auto_instrumentation, observed_env)
+        self.assertIn("cannot read all-dependencies.txt", output)
+        self.assertNotIn("unexpected error", output)
+
     def test_config_file_skips_protocol_guard_and_initializes(self):
         # With OTEL_CONFIG_FILE set, the SDK ignores the OTEL_* exporter
         # environment variables, so activation must proceed without


### PR DESCRIPTION
Fixes #116.

`importlib.metadata` decodes `METADATA` as UTF-8. A distribution whose file is not valid UTF-8 raises `UnicodeDecodeError`, and neither metadata guard in `sitecustomize.py` survived it, so one such package anywhere on `sys.path` deactivated auto-instrumentation for the whole process without naming it.

Two commits, because these are two independent defects and either fix is useful without the other.

## Observed, before and after

Bundle-shaped layout on `python:3.12-slim`, with one unrelated package carrying a Latin-1 author field (`Author: José García`), which is what older tooling on a non-UTF-8 system produces.

| scenario | before | after |
|---|---|---|
| broken package present | deactivated: `unexpected error ... UnicodeDecodeError` | skipped with a warning, instrumentation proceeds |
| broken package also named in `all-dependencies.txt` | deactivated, same message | both guards skip it, instrumentation proceeds |
| broken package **plus a real `opentelemetry-sdk`** | deactivated, same message | `opentelemetry-sdk 1.20.0 (/appsite)` correctly detected and named |

The third row is the one that matters most for review: skipping the unreadable distribution does not cost the scan the distribution it exists to find.

## Commit 1: guard each distribution in the double-instrumentation scan

`dist.metadata["Name"]` was read with nothing around it, so the first undecodable distribution aborted the scan and was caught only by #99's blanket handler.

It now skips that one distribution, which is what this file already does for an unparsable requirement and an unparsable version. The warning reports **the site directory the distribution is installed in**, not its name, because the name is exactly what could not be read. That narrows the search to a directory rather than pinpointing the package; `locate_file("")` resolves to the site directory for path-based installs, and I did not want to reach into the private `_path` that #99 deliberately moved away from in order to do better.

**The residual risk, stated plainly:** if the unreadable distribution is itself one of the guarded OpenTelemetry packages, the check can no longer see it. I think that trade is right, and it is the reason the message is a WARNING rather than a debug line: those packages are published with UTF-8 metadata by current tooling, no log level hides the warning, and it names a directory that will be an `opentelemetry-*` path in exactly that case. The alternative is today's behaviour, which loses telemetry in every process whenever any unrelated package is mis-encoded. Happy to invert this if you would rather keep failing closed.

## Commit 2: the error handler re-invoked the operation that failed

This one is a bug on its own and would be worth fixing even without the first.

`distribution(req.name)` is lazy and does not touch `METADATA`, so the decode error surfaces later at `installed_distribution.version`. That read is already inside a `try`, and `except Exception` did catch it. But the handler's own message quoted `installed_distribution.version` in its `format(...)` call, reading the attribute that had just failed. It raised a second time from inside the handler, so the function written to skip exactly this case could not, and the exception escaped.

An error path that re-invokes the failing operation in order to describe it cannot report that operation failing. The fix holds the value in a local first, so the parse handler quotes a string it already has.

Reading and parsing are now separate steps with separate messages, which also distinguishes two different operator problems: an unreadable `METADATA` and a Debian `dfsg` version suffix need different fixes.

## Verified

- The unit suite, 43 tests (40 before, plus 3 added here).
- **Each new test fails without its own commit.** The two double-instrumentation tests fail against `3e18ad7` with the reported `UnicodeDecodeError`, and the conflict-check test errors with the raw `UnicodeDecodeError` against commit 1's tree, which is what proves commit 2 is independently needed rather than incidental.
- `python2.7 -m py_compile`, so the parse contract on line 11 holds.
- `TestSitecustomize` in `packaging/tests/python`, `ok 11.133s`.
- The before/after table above, run end to end on a real layout.

## Notes for review

**The new tests use real objects, not `MagicMock`.** A `MagicMock` answers to every attribute and cannot raise on access, so it would quietly pass against the unfixed code. This follows the precedent already set by `test_deactivates_on_a_distribution_from_a_non_path_finder`.

**Based on `3e18ad7`**, so it includes #99, which is what currently catches these and turns them into the deactivation this PR prevents. It touches `_check_for_double_instrumentation` and `_check_dependency_version_conflict`, so it overlaps #105 (the double-instrumentation predicate) and #115 (the tidy-up); I will rebase onto whatever lands first.
