### PR TITLE
fix(python): treat an empty OTEL_EXPORTER_OTLP_PROTOCOL as unset

### DIFF
--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -272,16 +272,7 @@ def _exporter_for_protocol(otlp_protocol):
     # default of grpc. Returns the exporter entry-point name, or None if the
     # protocol is unsupported.
     #
-    # An empty value counts as unset, which the specification requires: "The
-    # SDK MUST interpret an empty value of an environment variable the same way
-    # as when the variable is unset." Testing only for None deactivated the
-    # agent over a blank value from a Kubernetes env: entry, a docker -e with
-    # nothing after the "=", or an expansion of a variable that was not set.
-    # OTEL_CONFIG_FILE, read a few lines below, already reads empty as unset.
-    #
-    # Surrounding whitespace is stripped for the same reason: it reaches the
-    # process from the same places a blank value does, and it cannot make a
-    # supported protocol ambiguous.
+    # A blank (empty or only-whitespaces) value counts as unset.
     protocol = (otlp_protocol or "").strip()
     if not protocol or protocol == "grpc":
         return "otlp_proto_grpc"

--- a/packaging/common/python/sitecustomize.py
+++ b/packaging/common/python/sitecustomize.py
@@ -271,9 +271,21 @@ def _exporter_for_protocol(otlp_protocol):
     # exporters emit protobuf only. An unset protocol follows the OpenTelemetry
     # default of grpc. Returns the exporter entry-point name, or None if the
     # protocol is unsupported.
-    if otlp_protocol is None or otlp_protocol == "grpc":
+    #
+    # An empty value counts as unset, which the specification requires: "The
+    # SDK MUST interpret an empty value of an environment variable the same way
+    # as when the variable is unset." Testing only for None deactivated the
+    # agent over a blank value from a Kubernetes env: entry, a docker -e with
+    # nothing after the "=", or an expansion of a variable that was not set.
+    # OTEL_CONFIG_FILE, read a few lines below, already reads empty as unset.
+    #
+    # Surrounding whitespace is stripped for the same reason: it reaches the
+    # process from the same places a blank value does, and it cannot make a
+    # supported protocol ambiguous.
+    protocol = (otlp_protocol or "").strip()
+    if not protocol or protocol == "grpc":
         return "otlp_proto_grpc"
-    if otlp_protocol == "http/protobuf":
+    if protocol == "http/protobuf":
         return "otlp_proto_http"
     return None
 

--- a/packaging/common/python/test_sitecustomize.py
+++ b/packaging/common/python/test_sitecustomize.py
@@ -347,6 +347,41 @@ class ImportDistroTests(unittest.TestCase):
         )
         self.assertEqual("", output)
 
+    def test_activates_with_grpc_when_protocol_is_empty(self):
+        # "The SDK MUST interpret an empty value of an environment variable the
+        # same way as when the variable is unset." A blank value reaches a
+        # process from a Kubernetes env: entry with no value, a docker -e with
+        # nothing after the "=", or an expansion of an unset variable, and it
+        # used to deactivate the agent over a configuration the SDK accepts.
+        output, auto_instrumentation, observed_env = self._exec_sitecustomize(
+            extra_env={"OTEL_EXPORTER_OTLP_PROTOCOL": ""},
+            all_dependencies="foo==1.0.0\n",
+        )
+        self._assert_activated(
+            auto_instrumentation, observed_env, exporter="otlp_proto_grpc"
+        )
+        self.assertEqual("", output)
+
+    def test_activates_with_grpc_when_protocol_is_only_whitespace(self):
+        output, auto_instrumentation, observed_env = self._exec_sitecustomize(
+            extra_env={"OTEL_EXPORTER_OTLP_PROTOCOL": "   "},
+            all_dependencies="foo==1.0.0\n",
+        )
+        self._assert_activated(
+            auto_instrumentation, observed_env, exporter="otlp_proto_grpc"
+        )
+        self.assertEqual("", output)
+
+    def test_activates_when_a_supported_protocol_carries_whitespace(self):
+        output, auto_instrumentation, observed_env = self._exec_sitecustomize(
+            extra_env={"OTEL_EXPORTER_OTLP_PROTOCOL": " http/protobuf\n"},
+            all_dependencies="foo==1.0.0\n",
+        )
+        self._assert_activated(
+            auto_instrumentation, observed_env, exporter="otlp_proto_http"
+        )
+        self.assertEqual("", output)
+
     def test_deactivates_when_protocol_is_http_json(self):
         # The bundled pyproto exporter emits protobuf only; http/json must be
         # rejected until the exporter chain supports JSON encoding.


### PR DESCRIPTION
Fixes #120.

`_exporter_for_protocol` tested the unset case with `is None`, so an empty value matched neither that nor either supported protocol and fell through to the `return None` the caller reads as "unsupported". Setting the variable to nothing deactivated the agent; leaving it out entirely activated with grpc.

The specification requires those two to be identical:

> The SDK MUST interpret an empty value of an environment variable the same way as when the variable is unset.

## Observed, before and after

Bundle-shaped layout on `python:3.12-slim`:

| `OTEL_EXPORTER_OTLP_PROTOCOL` | before | after |
|---|---|---|
| unset | `otlp_proto_grpc` | `otlp_proto_grpc` |
| empty | **deactivated** | `otlp_proto_grpc` |
| `"   "` | **deactivated** | `otlp_proto_grpc` |
| `" http/protobuf "` | **deactivated** | `otlp_proto_http` |
| `http/json` | deactivated | deactivated |

The last row is the point of the guard and is unchanged.

## This was rejecting a configuration that works

Worth separating from a guard doing its job: I installed `opentelemetry-sdk` and `opentelemetry-exporter-otlp-proto-grpc` and ran `_initialize_components()` with an empty `OTEL_EXPORTER_OTLP_PROTOCOL`. It initializes without complaint. So the agent was deactivating over something the SDK handles, and the cost was all of the process's telemetry.

That is what makes this different from the other guards: a blank environment variable is an ordinary deployment accident rather than an exotic input. `docker run -e OTEL_EXPORTER_OTLP_PROTOCOL=`, a Kubernetes `env:` entry with a blank `value:`, or `export OTEL_EXPORTER_OTLP_PROTOCOL="$SOME_VAR"` where `SOME_VAR` was never set all produce it.

## The file already disagreed with itself

`OTEL_CONFIG_FILE` is read a few lines below and tested with `if config_file:`, so an empty value there correctly behaves as unset. Two adjacent guards read two OTel environment variables and took opposite views of what a blank one means. This settles them on the specification's answer.

I checked the other variables the file reads: `OTEL_CONFIG_FILE` is correct as described and `OTEL_INJECTOR_LOG_LEVEL` is handled in #111, so this was the only one affected.

## The whitespace part is separable

Stripping surrounding whitespace is not required by the sentence quoted above; I included it because it arrives from the same places a blank value does (a YAML block scalar, a copied line with a trailing newline) and it cannot make a supported protocol ambiguous. Happy to drop it and keep only the empty-is-unset change if you would rather stay strictly with the specification. The `http/json` rejection is untouched either way.

## Verified

- The unit suite, 43 tests (40 before, plus 3 added here).
- All three new tests fail against `3e18ad7`.
- `python2.7 -m py_compile`, so the parse contract on line 11 holds.
- `TestSitecustomize` in `packaging/tests/python`, `ok 7.833s`.
- The before/after matrix above, run end to end on a real layout.

## Notes for review

**This overlaps #101**, which rewrites `_exporter_for_protocol` into per-signal resolution. Kept separate so it stays reviewable as a standalone specification-compliance fix and does not add scope to a PR already awaiting review; I will rebase whichever lands second, and the resolution is mechanical since #101's per-signal helper needs the same empty-is-unset treatment applied once rather than twice.

**Based on `3e18ad7`.**
