### PR TITLE
feat(builder): make the builder usable by vendor packages

### DIFF
--- a/cmd/build-packages/main.go
+++ b/cmd/build-packages/main.go
@@ -116,9 +116,12 @@ func main() {
 
 	for _, pkgFormat := range formats {
 		for _, comp := range components {
-			if err := builder.Build(cfg, pkgFormat, comp); err != nil {
+			outPath, err := builder.Build(cfg, pkgFormat, comp)
+			if err != nil {
 				log.Fatalf("error building %s %s: %v", pkgFormat, comp.Name, err)
 			}
+			fmt.Printf("Building %s: %s\n", pkgFormat, filepath.Base(outPath))
+			fmt.Printf("  -> %s\n", outPath)
 		}
 	}
 

--- a/packaging/builder/builder.go
+++ b/packaging/builder/builder.go
@@ -39,6 +39,43 @@ type Config struct {
 	// builder only assembles packages; the binary is cross-compiled upfront
 	// (see the otel-config-check Makefile target).
 	ConfigCheckBinary string
+
+	// Vendor, Maintainer, License and Homepage set the package identity
+	// fields. Each falls back to the OpenTelemetry default when empty, so a
+	// vendor building its own components (see the vendor package recipe in
+	// docs/design/packages-meta-architecture.md) can brand them without
+	// reimplementing the packaging rules.
+	Vendor     string
+	Maintainer string
+	License    string
+	Homepage   string
+
+	// NoticeFile is the NOTICE shipped in the documentation directory of the
+	// components that bundle third-party code. Empty resolves to the NOTICE
+	// next to PackagingDir, which is this repository's layout.
+	NoticeFile string
+}
+
+// Package identity, with the repository's own values as the defaults.
+func (c Config) vendor() string     { return orDefault(c.Vendor, pkgVendor) }
+func (c Config) maintainer() string { return orDefault(c.Maintainer, pkgMaintainer) }
+func (c Config) license() string    { return orDefault(c.License, pkgLicense) }
+func (c Config) homepage() string   { return orDefault(c.Homepage, pkgHomepage) }
+
+// noticeFile resolves the NOTICE path, defaulting to the file next to
+// PackagingDir.
+func (c Config) noticeFile() string {
+	if c.NoticeFile != "" {
+		return c.NoticeFile
+	}
+	return filepath.Join(filepath.Dir(c.PackagingDir), "NOTICE")
+}
+
+func orDefault(v, fallback string) string {
+	if v == "" {
+		return fallback
+	}
+	return v
 }
 
 // Relations declares a package's relationships to other packages.
@@ -49,6 +86,17 @@ type Relations struct {
 	Depends    []string
 	Recommends []string
 	Suggests   []string
+	// Conflicts and Replaces let a package displace another one. A vendor
+	// replacement declares the virtual name in Provides and the concrete
+	// upstream name in both of these, which is what makes the package manager
+	// swap the two in a single transaction.
+	//
+	// Replaces maps to DEB Replaces and RPM Obsoletes. The RPM side has a
+	// visible consequence: with both repositories enabled, installing the
+	// obsoleted name redirects to the replacement unless the client passes
+	// --setopt=obsoletes=0.
+	Conflicts []string
+	Replaces  []string
 }
 
 // Component describes a single package to build.
@@ -71,8 +119,14 @@ type Component struct {
 	// ContentsFunc stages the component's payload and returns its contents. It
 	// also returns a cleanup function that removes any staging directories,
 	// which must be called once packaging completes.
-	ContentsFunc func(cfg Config) (contents files.Contents, cleanup func(), err error)
+	ContentsFunc ContentsFunc
 }
+
+// ContentsFunc stages a component's payload. It returns the staged contents
+// and a cleanup function that removes any staging directories, which the
+// caller must invoke once packaging completes. Naming the type lets code
+// outside this package declare and compose payload builders.
+type ContentsFunc func(cfg Config) (contents files.Contents, cleanup func(), err error)
 
 // Arch returns the package architecture for the given format.
 func (c Component) Arch(cfg Config, format string) string {
@@ -99,16 +153,18 @@ func (c Component) Info(cfg Config, format string) (*nfpm.Info, func(), error) {
 		Arch:        c.Arch(cfg, format),
 		Platform:    "linux",
 		Description: c.Description,
-		Vendor:      pkgVendor,
-		Maintainer:  pkgMaintainer,
-		License:     pkgLicense,
-		Homepage:    pkgHomepage,
+		Vendor:      cfg.vendor(),
+		Maintainer:  cfg.maintainer(),
+		License:     cfg.license(),
+		Homepage:    cfg.homepage(),
 		Overridables: nfpm.Overridables{
 			Contents:   contents,
 			Provides:   c.Relations.Provides,
 			Depends:    c.Relations.Depends,
 			Recommends: c.Relations.Recommends,
 			Suggests:   c.Relations.Suggests,
+			Conflicts:  c.Relations.Conflicts,
+			Replaces:   c.Relations.Replaces,
 			RPM: nfpm.RPM{
 				Summary: c.Description,
 			},
@@ -146,43 +202,44 @@ var AllComponents = []Component{
 	Meta,
 }
 
-// Build creates a single package file.
-func Build(cfg Config, format string, comp Component) error {
+// Build creates a single package file and returns its path.
+//
+// It writes nothing to stdout: progress reporting is the caller's business, and
+// the returned path is what a caller needs to report or to hand to a signing or
+// publishing step.
+func Build(cfg Config, format string, comp Component) (string, error) {
 	info, cleanup, err := comp.Info(cfg, format)
 	if cleanup != nil {
 		defer cleanup()
 	}
 	if err != nil {
-		return fmt.Errorf("building info for %s: %w", comp.Name, err)
+		return "", fmt.Errorf("building info for %s: %w", comp.Name, err)
 	}
 
 	packager, err := nfpm.Get(format)
 	if err != nil {
-		return fmt.Errorf("getting %s packager: %w", format, err)
+		return "", fmt.Errorf("getting %s packager: %w", format, err)
 	}
 
-	fileName := packager.ConventionalFileName(info)
-	outPath := filepath.Join(cfg.OutputDir, fileName)
-	fmt.Printf("Building %s: %s\n", format, fileName)
+	outPath := filepath.Join(cfg.OutputDir, packager.ConventionalFileName(info))
 
 	f, err := os.Create(outPath)
 	if err != nil {
-		return fmt.Errorf("creating %s: %w", outPath, err)
+		return "", fmt.Errorf("creating %s: %w", outPath, err)
 	}
 
 	if err := packager.Package(info, f); err != nil {
 		f.Close()
 		os.Remove(outPath)
-		return fmt.Errorf("packaging %s: %w", comp.Name, err)
+		return "", fmt.Errorf("packaging %s: %w", comp.Name, err)
 	}
 
 	if err := f.Close(); err != nil {
 		os.Remove(outPath)
-		return fmt.Errorf("closing %s: %w", outPath, err)
+		return "", fmt.Errorf("closing %s: %w", outPath, err)
 	}
 
-	fmt.Printf("  -> %s\n", outPath)
-	return nil
+	return outPath, nil
 }
 
 // Common package metadata.
@@ -193,8 +250,18 @@ const (
 	pkgHomepage   = "https://github.com/open-telemetry/opentelemetry-packaging"
 )
 
-// configFile creates a Content entry for a config file (noreplace for RPM).
-func configFile(src, dst string) *files.Content {
+// The exported helpers below are the vocabulary for writing a ContentsFunc
+// outside this package. The unexported aliases keep the in-repo components
+// reading as before.
+var (
+	configFile  = ConfigFile
+	regularFile = RegularFile
+	directory   = Directory
+	tree        = Tree
+)
+
+// ConfigFile creates a Content entry for a config file (noreplace for RPM).
+func ConfigFile(src, dst string) *files.Content {
 	return &files.Content{
 		Source:      src,
 		Destination: dst,
@@ -205,8 +272,8 @@ func configFile(src, dst string) *files.Content {
 	}
 }
 
-// regularFile creates a Content entry for a regular file.
-func regularFile(src, dst string, mode os.FileMode) *files.Content {
+// RegularFile creates a Content entry for a regular file.
+func RegularFile(src, dst string, mode os.FileMode) *files.Content {
 	return &files.Content{
 		Source:      src,
 		Destination: dst,
@@ -216,8 +283,8 @@ func regularFile(src, dst string, mode os.FileMode) *files.Content {
 	}
 }
 
-// directory creates a Content entry for an empty directory.
-func directory(dst string) *files.Content {
+// Directory creates a Content entry for an empty directory.
+func Directory(dst string) *files.Content {
 	return &files.Content{
 		Destination: dst,
 		Type:        "dir",
@@ -227,8 +294,8 @@ func directory(dst string) *files.Content {
 	}
 }
 
-// tree creates a Content entry that includes an entire directory tree.
-func tree(src, dst string) *files.Content {
+// Tree creates a Content entry that includes an entire directory tree.
+func Tree(src, dst string) *files.Content {
 	return &files.Content{
 		Source:      src,
 		Destination: dst,

--- a/packaging/builder/components.go
+++ b/packaging/builder/components.go
@@ -134,7 +134,7 @@ func injectorContents(cfg Config) (files.Contents, func(), error) {
 		return nil, cleanup, fmt.Errorf("downloading injector: %w", err)
 	}
 
-	manPath, err := generateManPage(cfg, staging, "injector")
+	manPath, err := GenerateManPage(cfg, staging, manPageTemplate(cfg, "injector"))
 	if err != nil {
 		return nil, cleanup, err
 	}
@@ -163,7 +163,7 @@ func javaContents(cfg Config) (files.Contents, func(), error) {
 		return nil, cleanup, fmt.Errorf("downloading Java agent: %w", err)
 	}
 
-	manPath, err := generateManPage(cfg, staging, "java")
+	manPath, err := GenerateManPage(cfg, staging, manPageTemplate(cfg, "java"))
 	if err != nil {
 		return nil, cleanup, err
 	}
@@ -190,7 +190,7 @@ func nodejsContents(cfg Config) (files.Contents, func(), error) {
 		return nil, cleanup, fmt.Errorf("downloading Node.js agent: %w", err)
 	}
 
-	manPath, err := generateManPage(cfg, staging, "nodejs")
+	manPath, err := GenerateManPage(cfg, staging, manPageTemplate(cfg, "nodejs"))
 	if err != nil {
 		return nil, cleanup, err
 	}
@@ -222,7 +222,7 @@ func dotnetContents(cfg Config) (files.Contents, func(), error) {
 		return nil, cleanup, fmt.Errorf("downloading .NET agent: %w", err)
 	}
 
-	manPath, err := generateManPage(cfg, staging, "dotnet")
+	manPath, err := GenerateManPage(cfg, staging, manPageTemplate(cfg, "dotnet"))
 	if err != nil {
 		return nil, cleanup, err
 	}
@@ -281,7 +281,7 @@ func pythonContents(cfg Config) (files.Contents, func(), error) {
 		return nil, cleanup, fmt.Errorf("generating all-dependencies.txt: %w", err)
 	}
 
-	manPath, err := generateManPage(cfg, staging, "python")
+	manPath, err := GenerateManPage(cfg, staging, manPageTemplate(cfg, "python"))
 	if err != nil {
 		return nil, cleanup, err
 	}
@@ -300,7 +300,7 @@ func pythonContents(cfg Config) (files.Contents, func(), error) {
 		// The bundle redistributes files derived from the Dash0 operator; the
 		// NOTICE at the repository root carries the attribution required by
 		// Apache-2.0 and ships alongside the package documentation.
-		regularFile(filepath.Join(filepath.Dir(cfg.PackagingDir), "NOTICE"), "/usr/share/doc/opentelemetry-python-autoinstrumentation/NOTICE", 0o644),
+		regularFile(cfg.noticeFile(), "/usr/share/doc/opentelemetry-python-autoinstrumentation/NOTICE", 0o644),
 	}, cleanup, nil
 }
 
@@ -321,13 +321,26 @@ func metaContents(cfg Config) (files.Contents, func(), error) {
 	}, cleanup, nil
 }
 
-// generateManPage expands @VERSION@ and @DATE@ placeholders in a man page
-// template, compresses with gzip, and writes the result into stagingDir.
-// Returns the path to the gzipped file.
-func generateManPage(cfg Config, stagingDir, component string) (string, error) {
-	templateName := fmt.Sprintf("opentelemetry-%s.8.tmpl", component)
+// manPageTemplate locates a component's man page template in this
+// repository's layout: packaging/common/<component>/opentelemetry-<component>.8.tmpl.
+func manPageTemplate(cfg Config, component string) string {
+	return filepath.Join(cfg.PackagingDir, "common", component,
+		fmt.Sprintf("opentelemetry-%s.8.tmpl", component))
+}
 
-	templatePath := filepath.Join(cfg.PackagingDir, "common", component, templateName)
+// GenerateManPage expands @VERSION@ and @DATE@ placeholders in the man page
+// template at templatePath, compresses it with gzip, and writes the result
+// into stagingDir. It returns the path to the gzipped file.
+//
+// The template is addressed by path rather than derived from a component name,
+// so a caller is free to name its templates whatever its packages are called.
+// The output file keeps the template's own name minus the .tmpl suffix.
+func GenerateManPage(cfg Config, stagingDir, templatePath string) (string, error) {
+	templateName := filepath.Base(templatePath)
+	if !strings.HasSuffix(templateName, ".tmpl") {
+		return "", fmt.Errorf("man page template %q must end in .tmpl", templateName)
+	}
+
 	tmplData, err := os.ReadFile(templatePath)
 	if err != nil {
 		return "", fmt.Errorf("reading man page template: %w", err)
@@ -337,7 +350,7 @@ func generateManPage(cfg Config, stagingDir, component string) (string, error) {
 	content = strings.ReplaceAll(content, "@VERSION@", cfg.Version)
 	content = strings.ReplaceAll(content, "@DATE@", time.Now().Format("January 2006"))
 
-	outPath := filepath.Join(stagingDir, templateName[:len(templateName)-5]+".gz")
+	outPath := filepath.Join(stagingDir, strings.TrimSuffix(templateName, ".tmpl")+".gz")
 	f, err := os.Create(outPath)
 	if err != nil {
 		return "", err

--- a/packaging/builder/opentelemetry-packaging.spec.tmpl
+++ b/packaging/builder/opentelemetry-packaging.spec.tmpl
@@ -102,6 +102,10 @@ Summary:        {{ .Summary }}
 {{ end -}}
 {{ range .Requires }}Requires:       {{ . }}
 {{ end -}}
+{{ range .Conflicts }}Conflicts:      {{ . }}
+{{ end -}}
+{{ range .Replaces }}Obsoletes:      {{ . }}
+{{ end -}}
 {{ range .Recommends }}
 {{- if .Guarded }}{{ $.PythonGuard }}
 Recommends:     {{ .Name }}

--- a/packaging/builder/spec.go
+++ b/packaging/builder/spec.go
@@ -80,6 +80,10 @@ type specPackage struct {
 	Requires    []string
 	Recommends  []specRelation
 	Suggests    []string
+	Conflicts   []string
+	// Replaces carries Relations.Replaces. The template emits it as the RPM
+	// Obsoletes tag, which is that relationship's spelling in a spec file.
+	Replaces []string
 	// Guarded marks a package whose stanzas sit inside the Python conditional.
 	Guarded bool
 }
@@ -116,8 +120,8 @@ func WriteSpec(cfg Config, w io.Writer) error {
 		Version:       version,
 		Release:       release,
 		Summary:       metaDescription,
-		License:       pkgLicense,
-		URL:           pkgHomepage,
+		License:       cfg.license(),
+		URL:           cfg.homepage(),
 		ExclusiveArch: specExclusiveArch,
 		BuildRequires: specBuildRequires,
 		PythonGuard:   pythonGuard,
@@ -136,6 +140,8 @@ func WriteSpec(cfg Config, w io.Writer) error {
 			Provides:    comp.Relations.Provides,
 			Requires:    comp.Relations.Depends,
 			Suggests:    comp.Relations.Suggests,
+			Conflicts:   comp.Relations.Conflicts,
+			Replaces:    comp.Relations.Replaces,
 			Guarded:     guarded,
 		}
 		for _, r := range comp.Relations.Recommends {

--- a/packaging/builder/vendor_api_test.go
+++ b/packaging/builder/vendor_api_test.go
@@ -1,0 +1,230 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package builder
+
+import (
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/goreleaser/nfpm/v2/files"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fixtureComponent is a minimal component standing in for a vendor package. It
+// stages one file from a temporary directory, so it needs no PackagingDir.
+func fixtureComponent(t *testing.T, rel Relations) Component {
+	t.Helper()
+	return Component{
+		Name:        "fixture",
+		PackageName: "fixture-autoinstrumentation",
+		Description: "Fixture package",
+		Noarch:      true,
+		Relations:   rel,
+		ContentsFunc: func(Config) (files.Contents, func(), error) {
+			dir := t.TempDir()
+			payload := filepath.Join(dir, "payload")
+			if err := os.WriteFile(payload, []byte("payload\n"), 0o644); err != nil {
+				return nil, nil, err
+			}
+			return files.Contents{
+				RegularFile(payload, "/usr/lib/opentelemetry/fixture/payload", 0o644),
+			}, func() {}, nil
+		},
+	}
+}
+
+// TestIdentityDefaults pins the promise that an empty Config keeps the
+// repository's own package identity, so adding the override fields changes
+// nothing for existing callers.
+func TestIdentityDefaults(t *testing.T) {
+	cfg := Config{Version: "1.2.3", Arch: "amd64"}
+
+	assert.Equal(t, pkgVendor, cfg.vendor())
+	assert.Equal(t, pkgMaintainer, cfg.maintainer())
+	assert.Equal(t, pkgLicense, cfg.license())
+	assert.Equal(t, pkgHomepage, cfg.homepage())
+
+	info, cleanup, err := fixtureComponent(t, Relations{}).Info(cfg, "deb")
+	if cleanup != nil {
+		defer cleanup()
+	}
+	require.NoError(t, err)
+	assert.Equal(t, "OpenTelemetry", info.Vendor)
+	assert.Equal(t, "The OpenTelemetry Authors", info.Maintainer)
+	assert.Equal(t, "Apache-2.0", info.License)
+	assert.Equal(t, pkgHomepage, info.Homepage)
+}
+
+// TestIdentityOverride covers the vendor case: branding the package without
+// touching the packaging rules.
+func TestIdentityOverride(t *testing.T) {
+	cfg := Config{
+		Version:    "1.2.3",
+		Arch:       "amd64",
+		Vendor:     "ACME",
+		Maintainer: "The ACME Company",
+		License:    "MIT",
+		Homepage:   "https://acme.example",
+	}
+
+	info, cleanup, err := fixtureComponent(t, Relations{}).Info(cfg, "deb")
+	if cleanup != nil {
+		defer cleanup()
+	}
+	require.NoError(t, err)
+	assert.Equal(t, "ACME", info.Vendor)
+	assert.Equal(t, "The ACME Company", info.Maintainer)
+	assert.Equal(t, "MIT", info.License)
+	assert.Equal(t, "https://acme.example", info.Homepage)
+}
+
+// TestRelationsConflictsReplaces is the core of the vendor recipe: the virtual
+// name in Provides, the concrete upstream name in Conflicts and Replaces.
+func TestRelationsConflictsReplaces(t *testing.T) {
+	comp := fixtureComponent(t, Relations{
+		Provides:  []string{"opentelemetry-java-autoinstrumentation1"},
+		Conflicts: []string{"opentelemetry-java-autoinstrumentation"},
+		Replaces:  []string{"opentelemetry-java-autoinstrumentation"},
+		Suggests:  []string{"opentelemetry-injector1"},
+	})
+
+	for _, format := range []string{"deb", "rpm"} {
+		t.Run(format, func(t *testing.T) {
+			info, cleanup, err := comp.Info(Config{Version: "1.0.0", Arch: "amd64"}, format)
+			if cleanup != nil {
+				defer cleanup()
+			}
+			require.NoError(t, err)
+			assert.Equal(t, []string{"opentelemetry-java-autoinstrumentation1"}, info.Provides)
+			assert.Equal(t, []string{"opentelemetry-java-autoinstrumentation"}, info.Conflicts)
+			assert.Equal(t, []string{"opentelemetry-java-autoinstrumentation"}, info.Replaces)
+			assert.Equal(t, []string{"opentelemetry-injector1"}, info.Suggests)
+		})
+	}
+}
+
+// TestUpstreamComponentsDeclareNoDisplacement guards the additive claim: none
+// of the shipped components displaces anything, so the new fields cannot alter
+// their metadata.
+func TestUpstreamComponentsDeclareNoDisplacement(t *testing.T) {
+	for _, comp := range AllComponents {
+		t.Run(comp.Name, func(t *testing.T) {
+			assert.Empty(t, comp.Relations.Conflicts)
+			assert.Empty(t, comp.Relations.Replaces)
+		})
+	}
+}
+
+// TestContentHelperAliases keeps the exported helpers and the in-repo
+// unexported names interchangeable, so components read the same either way.
+func TestContentHelperAliases(t *testing.T) {
+	assert.Equal(t, configFile("s", "d"), ConfigFile("s", "d"))
+	assert.Equal(t, regularFile("s", "d", 0o600), RegularFile("s", "d", 0o600))
+	assert.Equal(t, directory("d"), Directory("d"))
+	assert.Equal(t, tree("s", "d"), Tree("s", "d"))
+
+	// The nfpm types carry the packaging semantics, so pin them too.
+	assert.Equal(t, "config|noreplace", ConfigFile("s", "d").Type)
+	assert.Equal(t, os.FileMode(0o644), os.FileMode(ConfigFile("s", "d").FileInfo.Mode))
+	assert.Equal(t, "dir", Directory("d").Type)
+	assert.Equal(t, os.FileMode(0o755), os.FileMode(Directory("d").FileInfo.Mode))
+	assert.Equal(t, "tree", Tree("s", "d").Type)
+}
+
+// TestGenerateManPageArbitraryTemplate covers a vendor naming its man pages
+// after its own packages rather than after opentelemetry-<component>.
+func TestGenerateManPageArbitraryTemplate(t *testing.T) {
+	dir := t.TempDir()
+	tmpl := filepath.Join(dir, "acme-java.8.tmpl")
+	require.NoError(t, os.WriteFile(tmpl, []byte("version @VERSION@ dated @DATE@\n"), 0o644))
+
+	staging := t.TempDir()
+	out, err := GenerateManPage(Config{Version: "9.9.9"}, staging, tmpl)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(staging, "acme-java.8.gz"), out)
+
+	f, err := os.Open(out)
+	require.NoError(t, err)
+	defer f.Close()
+	gr, err := gzip.NewReader(f)
+	require.NoError(t, err)
+	body, err := io.ReadAll(gr)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(body), "version 9.9.9 dated ")
+	assert.NotContains(t, string(body), "@VERSION@")
+	assert.NotContains(t, string(body), "@DATE@")
+}
+
+func TestGenerateManPageRejectsNonTemplate(t *testing.T) {
+	_, err := GenerateManPage(Config{Version: "1.0.0"}, t.TempDir(), "/nowhere/acme-java.8")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ".tmpl")
+}
+
+// TestNoticeFile checks the default still resolves to the repository layout,
+// and that a caller can point it elsewhere.
+func TestNoticeFile(t *testing.T) {
+	cfg := Config{PackagingDir: "/src/repo/packaging"}
+	assert.Equal(t, filepath.Join("/src/repo", "NOTICE"), cfg.noticeFile())
+
+	cfg.NoticeFile = "/elsewhere/NOTICE"
+	assert.Equal(t, "/elsewhere/NOTICE", cfg.noticeFile())
+}
+
+// TestBuildReturnsPath covers Build handing back the artifact path, which a
+// caller needs in order to report, sign, or publish it.
+func TestBuildReturnsPath(t *testing.T) {
+	out := t.TempDir()
+	cfg := Config{Version: "1.0.0", Arch: "amd64", OutputDir: out, Vendor: "ACME"}
+
+	path, err := Build(cfg, "deb", fixtureComponent(t, Relations{}))
+	require.NoError(t, err)
+
+	assert.Equal(t, out, filepath.Dir(path))
+	assert.Equal(t, "fixture-autoinstrumentation_1.0.0_all.deb", filepath.Base(path))
+	st, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Positive(t, st.Size())
+}
+
+// TestWriteSpecRendersDisplacement checks the rpmbuild path keeps parity with
+// nfpm, so a vendor gets the same relations from either producer.
+func TestWriteSpecRendersDisplacement(t *testing.T) {
+	original := AllComponents
+	t.Cleanup(func() { AllComponents = original })
+	AllComponents = append(append([]Component{}, original...), fixtureComponent(t, Relations{
+		Provides:  []string{"opentelemetry-java-autoinstrumentation1"},
+		Conflicts: []string{"opentelemetry-java-autoinstrumentation"},
+		Replaces:  []string{"opentelemetry-java-autoinstrumentation"},
+	}))
+
+	var b strings.Builder
+	require.NoError(t, WriteSpec(testConfig(t, "1.0.0"), &b))
+	spec := b.String()
+
+	assert.Contains(t, spec, "Conflicts:      opentelemetry-java-autoinstrumentation")
+	// Obsoletes is how a spec file spells Replaces.
+	assert.Contains(t, spec, "Obsoletes:      opentelemetry-java-autoinstrumentation")
+}
+
+// TestWriteSpecIdentityOverride covers the spec path reading identity from
+// Config, which is the half of the seam that is easy to leave behind.
+func TestWriteSpecIdentityOverride(t *testing.T) {
+	cfg := testConfig(t, "1.0.0")
+	cfg.License = "MIT"
+	cfg.Homepage = "https://acme.example"
+
+	var b strings.Builder
+	require.NoError(t, WriteSpec(cfg, &b))
+	spec := b.String()
+
+	assert.Contains(t, spec, "License:        MIT")
+	assert.Contains(t, spec, "URL:            https://acme.example")
+}


### PR DESCRIPTION
This change generalizes `packaging/builder` to be usable by a vendor to created vendored packages spec'd in docs/design/packages-meta-architecture.md.

Fixes #124